### PR TITLE
feat(api): adds scan summary

### DIFF
--- a/backend/src/api/routes/scans/index.ts
+++ b/backend/src/api/routes/scans/index.ts
@@ -7,6 +7,7 @@ import listRoute from './list'
 import viewRoute from './view'
 import deleteRoute from './delete'
 import bulkDeleteRoute from './bulk-delete'
+import summaryRoute from './summary'
 
 const AdminScope = AuthPathOp(Scope(Authorized, 'admin'))
 
@@ -15,5 +16,6 @@ export default (router: Router): { paths: PathItem[]; router: Router } =>
     router,
     Path('/', AuthScope(listRoute)),
     Path(`/:id(${uuidFormat})`, AuthScope(viewRoute), AdminScope(deleteRoute)),
-    Path('/bulk_delete', AdminScope(bulkDeleteRoute))
+    Path('/bulk_delete', AdminScope(bulkDeleteRoute)),
+    Path(`/:id(${uuidFormat})/summary`, summaryRoute)
   )

--- a/backend/src/api/routes/scans/summary.ts
+++ b/backend/src/api/routes/scans/summary.ts
@@ -1,0 +1,65 @@
+import { Request, Response, NextFunction } from 'express'
+
+import { AsyncGet } from 'aejo'
+import { uuidParams } from '../alerts/schemas'
+import ScanService from '../../../services/scan'
+
+export default AsyncGet({
+  tags: ['scans'],
+  description: 'Scan Summary',
+  parameters: [uuidParams],
+  middleware: [
+    async (req: Request, res: Response, next: NextFunction): Promise<void> => {
+      const { id } = req.params
+      await ScanService.view(id)
+      const summary = await ScanService.summary(id)
+      res.status(200).json(summary)
+      next()
+    }
+  ],
+  responses: {
+    200: {
+      description: 'Ok',
+      content: {
+        'application/json': {
+          schema: {
+            type: 'object',
+            properties: {
+              requests: {
+                type: 'array',
+                description: 'Number of times domain was requested',
+                items: {
+                  type: 'array',
+                  example: ['www.foo.com', 5]
+                }
+              },
+              totalAlerts: {
+                description: 'Number of alerts',
+                type: 'integer'
+              },
+              totalCookies: {
+                description: 'Number of cookies set',
+                type: 'integer'
+              },
+              totalErrors: {
+                description: 'Number of script/page errors',
+                type: 'integer'
+              },
+              totalFunc: {
+                description: 'Number of function calls',
+                type: 'integer'
+              },
+              totalReq: {
+                description: 'Number of web requests',
+                type: 'integer'
+              }
+            }
+          }
+        }
+      }
+    },
+    404: {
+      description: 'Not Found'
+    }
+  }
+})

--- a/backend/src/services/scan_logs.ts
+++ b/backend/src/services/scan_logs.ts
@@ -76,6 +76,14 @@ async function handleFailed(job: Job<MerryMaker.EventResult>) {
   )
 }
 
+const getByScanID = async (
+  id: string,
+  whereBuilder?: Modifier<QueryBuilder<ScanLog, ScanLog[]>>
+): Promise<ScanLog[]> =>
+  ScanLog.query()
+    .where('scan_id', id)
+    .modify(whereBuilder)
+
 const view = async (id: string): Promise<ScanLog> =>
   ScanLog.query()
     .findById(id)
@@ -167,5 +175,6 @@ export default {
   view,
   distinct,
   countByScanID,
+  getByScanID,
   siteScanCache
 }

--- a/backend/src/tests/scan.service.test.ts
+++ b/backend/src/tests/scan.service.test.ts
@@ -5,17 +5,19 @@ import SourceFactory from './factories/sources.factory'
 import ScanLogFactory from './factories/scan_log.factory'
 import { resetDB } from './utils'
 import { ScanAttributes } from '../models/scans'
-import {WebRequestEvent} from '@merrymaker/types'
+import { WebRequestEvent } from '@merrymaker/types'
 
 const helper = async (scanAttrs: Partial<ScanAttributes> = {}) => {
-  const sourceModel = await SourceFactory.build().$query().insert()
+  const sourceModel = await SourceFactory.build()
+    .$query()
+    .insert()
   const siteModel = await SiteFactory.build({ source_id: sourceModel.id })
     .$query()
     .insert()
   return ScanFactory.build({
     source_id: sourceModel.id,
     site_id: siteModel.id,
-    ...scanAttrs,
+    ...scanAttrs
   })
     .$query()
     .insert()
@@ -28,20 +30,22 @@ describe('Scan Service', () => {
   it('deletes scans older than 5 days', async () => {
     const now = new Date()
     const fiveDaysAgo = new Date(new Date().setDate(now.getDate() - 5))
-    const sourceModel = await SourceFactory.build().$query().insert()
+    const sourceModel = await SourceFactory.build()
+      .$query()
+      .insert()
     const siteModel = await SiteFactory.build({ source_id: sourceModel.id })
       .$query()
       .insert()
     await ScanFactory.build({
       created_at: fiveDaysAgo,
       source_id: sourceModel.id,
-      site_id: siteModel.id,
+      site_id: siteModel.id
     })
       .$query()
       .insert()
     await ScanFactory.build({
       source_id: sourceModel.id,
-      site_id: siteModel.id,
+      site_id: siteModel.id
     })
       .$query()
       .insert()
@@ -51,7 +55,9 @@ describe('Scan Service', () => {
   it('deletes test scans 6 hours or older', async () => {
     const now = new Date()
     const sixHoursAgo = new Date(new Date().setHours(now.getHours() - 6))
-    const sourceModel = await SourceFactory.build().$query().insert()
+    const sourceModel = await SourceFactory.build()
+      .$query()
+      .insert()
     const siteModel = await SiteFactory.build({ source_id: sourceModel.id })
       .$query()
       .insert()
@@ -59,13 +65,13 @@ describe('Scan Service', () => {
       created_at: sixHoursAgo,
       source_id: sourceModel.id,
       site_id: siteModel.id,
-      test: true,
+      test: true
     })
       .$query()
       .insert()
     await ScanFactory.build({
       source_id: sourceModel.id,
-      site_id: siteModel.id,
+      site_id: siteModel.id
     })
       .$query()
       .insert()
@@ -90,7 +96,7 @@ describe('Scan Service', () => {
       const activeScanB = await helper({ state: 'done' })
       const res = await ScanService.isBulkActive([
         activeScanA.id,
-        activeScanB.id,
+        activeScanB.id
       ])
       expect(res).toBe(true)
     })
@@ -99,7 +105,7 @@ describe('Scan Service', () => {
       const activeScanB = await helper({ state: 'done' })
       const res = await ScanService.isBulkActive([
         activeScanA.id,
-        activeScanB.id,
+        activeScanB.id
       ])
       expect(res).toBe(false)
     })

--- a/backend/src/tests/scans.controller.test.ts
+++ b/backend/src/tests/scans.controller.test.ts
@@ -9,7 +9,7 @@ import SourceFactory from './factories/sources.factory'
 import ScanLogFactory from './factories/scan_log.factory'
 
 import { makeSession, resetDB } from './utils'
-import {WebRequestEvent} from '@merrymaker/types'
+import { WebRequestEvent } from '@merrymaker/types'
 
 const chance = Chance()
 
@@ -21,7 +21,7 @@ const userSession = () =>
     lanid: 'z000n00',
     email: 'foo@example.com',
     isAuth: true,
-    exp: 0,
+    exp: 0
   }).app
 
 const adminSession = () =>
@@ -32,7 +32,7 @@ const adminSession = () =>
     role: 'admin',
     lanid: 'z000n00',
     email: 'foo@example.com',
-    isAuth: true,
+    isAuth: true
   }).app
 
 describe('Scan Controller', () => {
@@ -43,7 +43,9 @@ describe('Scan Controller', () => {
   beforeEach(async () => {
     await resetDB()
     // Site needs a source
-    sourceSeed = await SourceFactory.build().$query().insert()
+    sourceSeed = await SourceFactory.build()
+      .$query()
+      .insert()
     // Scan needs a valid Site
     siteSeedA = await SiteFactory.build({ source_id: sourceSeed.id })
       .$query()
@@ -53,7 +55,7 @@ describe('Scan Controller', () => {
       .insert()
     seedA = await ScanFactory.build({
       site_id: siteSeedA.id,
-      source_id: sourceSeed.id,
+      source_id: sourceSeed.id
     })
       .$query()
       .insert()
@@ -91,7 +93,7 @@ describe('Scan Controller', () => {
       const activeScan = await ScanFactory.build({
         site_id: siteSeedA.id,
         source_id: sourceSeed.id,
-        state: 'active',
+        state: 'active'
       })
         .$query()
         .insert()
@@ -128,5 +130,4 @@ describe('Scan Controller', () => {
       expect(res.body.totalReq).toBe(10)
     })
   })
-
 })

--- a/frontend/src/components/scans/ScanSummary.vue
+++ b/frontend/src/components/scans/ScanSummary.vue
@@ -1,0 +1,139 @@
+<template>
+  <v-row>
+    <v-col cols="12" md="4">
+      <v-card class="mx-auto" outlined>
+        <v-card-title class="secondary ligthen-1 white--text">
+          Domains
+        </v-card-title>
+        <v-card-text>
+          <template v-if="summary.totalReq > 0">
+            <v-list dense class="scroll" height="300px">
+              <v-list-item
+                v-for="[domain, total] in summary.requests.domain"
+                :key="domain"
+              >
+              <v-list-item-icon>
+                <v-icon>mdi-web</v-icon>
+              </v-list-item-icon>
+              <v-list-item-content>
+                <v-list-item-title>
+                  {{ domain }}
+                </v-list-item-title>
+              </v-list-item-content>
+                {{ total.toLocaleString() }}
+              </v-list-item>
+            </v-list>
+          </template>
+          <template>
+            <h3 class="text-center">
+              None
+            </h3>
+          </template>
+        </v-card-text>
+      </v-card>
+    </v-col>
+    <v-col cols="12" md="3">
+      <v-card class="mx-auto" outlined>
+        <v-card-title class="secondary ligthen-1 white--text">
+          Totals
+        </v-card-title>
+        <v-card-text>
+          <v-list dense height="300px">
+            <v-list-item v-for="count in counts" :key="count.key">
+              <v-list-item-icon>
+                <v-icon>{{ count.icon }}</v-icon>
+              </v-list-item-icon>
+              <v-list-item-content>
+                <v-list-item-title>
+                  {{ count.title }}
+                </v-list-item-title>
+              </v-list-item-content>
+              {{ summary[count.key].toLocaleString() }}
+            </v-list-item>
+          </v-list>
+        </v-card-text>
+      </v-card>
+    </v-col>
+  </v-row>
+</template>
+
+<script lang="ts">
+import Vue from 'vue'
+import ScanAPIService from '@/services/scans'
+
+import NotifyMixin from '../../mixins/notify'
+
+const summaryTotals = [
+  {
+    icon: 'mdi-lan-connect',
+    title: 'Requests',
+    key: 'totalReq'
+  },
+  {
+    icon: 'mdi-alert',
+    title: 'Alerts',
+    key: 'totalAlerts'
+  },
+  {
+    icon: 'mdi-skull',
+    title: 'Errors',
+    key: 'totalErrors'
+  },
+  {
+    icon: 'mdi-code-parentheses',
+    title: 'Function Calls',
+    key: 'totalFunc'
+  },
+  {
+    icon: 'mdi-cookie',
+    title: 'Cookies',
+    key: 'totalCookies'
+  }
+]
+
+export default Vue.extend({
+  name: 'ScanSummary',
+  props: {
+    scanID: String
+  },
+  mixins: [NotifyMixin],
+  data() {
+    return {
+      init: false,
+      scan: {},
+      summary: {},
+      counts: [{}]
+    }
+  },
+  methods: {
+    async getScan() {
+      const res = await ScanAPIService.view({
+        id: this.scanID,
+        eager: ['sites']
+      })
+      this.scan = res.data
+    },
+    async getSummary() {
+      const res = await ScanAPIService.summary({ id: this.scanID })
+      this.summary = res.data
+    }
+  },
+  async created() {
+    try {
+      await this.getScan()
+      await this.getSummary()
+      this.counts = summaryTotals
+      Object.freeze(this.counts)
+      this.init = true
+    } catch (e) {
+      this.errorHandler(e)
+    }
+  }
+})
+</script>
+
+<style scoped>
+.scroll {
+  overflow-y: scroll;
+}
+</style>

--- a/frontend/src/services/scans.ts
+++ b/frontend/src/services/scans.ts
@@ -25,6 +25,15 @@ export interface ScanListRequest extends ListRequest<ScanAttributes> {
   no_test?: boolean
 }
 
+export interface ScanSummary {
+  requests: Record<string, Array<[string, number]>>
+  totalReq: number
+  totalAlerts: number
+  totalErrors: number
+  totalFunc: number
+  totalCookies: number
+}
+
 const list = async (params?: ScanListRequest) =>
   axios.get<ObjectListResult<ScanAttributes>>('/api/scans', { params })
 
@@ -32,6 +41,9 @@ const view = async (params: { id: string; eager?: EagerLoad[] }) =>
   axios.get<ScanAttributes>(`/api/scans/${params.id}`, {
     params: { eager: params.eager },
   })
+
+const summary = (params: { id: string }) =>
+  axios.get<ScanSummary>(`/api/scans/${params.id}/summary`)
 
 const destroy = async (params: { id: string }) =>
   axios.delete(`/api/scans/${params.id}`)
@@ -44,4 +56,5 @@ export default {
   view,
   destroy,
   bulkDelete,
+  summary,
 }

--- a/frontend/src/views/scans/ScanLog.vue
+++ b/frontend/src/views/scans/ScanLog.vue
@@ -2,7 +2,25 @@
   <v-container id="scan-log" fluid tag="section" v-if="init">
     <v-row>
       <v-col cols="12">
+        <v-toolbar flat id="scan-log-toolbar">
+          <v-toolbar-title
+            >{{ scan.site ? scan.site.name : 'No Site' }} /
+            {{ scan.source ? scan.source.name : 'No Source' }}</v-toolbar-title
+          >
+        </v-toolbar>
+        <v-expansion-panels>
+          <v-expansion-panel>
+            <v-expansion-panel-header>
+              Summary
+            </v-expansion-panel-header>
+            <v-expansion-panel-content>
+              <scan-summary :scanID="scanID" />
+            </v-expansion-panel-content>
+          </v-expansion-panel>
+        </v-expansion-panels>
+        <v-divider class="mb-2"></v-divider>
         <v-data-table
+          class="pa-md-2"
           :headers="headers"
           :items="records"
           :options.sync="options"
@@ -12,19 +30,11 @@
           :sort-desc.sync="sortDesc"
           :loading="loading"
           :items-per-page.sync="itemsPerPage"
-          :footer-props="{ itemsPerPageOptions: [10, 25, 50, 100, -1] }"
-          class="elevation-1"
+          :footer-props="{itemsPerPageOptions:[10,25,50,100,-1] }"
           @page-count="pageCount = $event"
         >
           <template v-slot:top>
-            <v-toolbar flat id="scan-log-toolbar">
-              <v-toolbar-title
-                >{{ scan.site ? scan.site.name : 'No Site' }} /
-                {{
-                  scan.source ? scan.source.name : 'No Source'
-                }}</v-toolbar-title
-              >
-              <v-spacer></v-spacer>
+            <v-toolbar flat>
               <v-text-field
                 color="secondary"
                 hide-details
@@ -88,6 +98,7 @@ import VueJsonPretty from 'vue-json-pretty'
 import 'vue-json-pretty/lib/styles.css'
 import ScanLogAPIService, { ScanLogAttributes } from '@/services/scan_logs'
 import ScanAPIService, { ScanAttributes } from '@/services/scans'
+import ScanSummary from '@/components/scans/ScanSummary.vue'
 import '../../assets/sass/scan-logs.scss'
 
 import TableMixin, { TableMixinBindings } from '@/mixins/table'
@@ -104,7 +115,7 @@ const escapeEntit: Record<string, string> = {
   '<': '&lt;',
   '>': '&gt;',
   "'": '&#39;',
-  '"': '&quot;',
+  '"': '&quot;'
 }
 
 const logTypeIcons: Record<LogEntryTypes, string> = {
@@ -112,7 +123,7 @@ const logTypeIcons: Record<LogEntryTypes, string> = {
   screenshot: 'monitor',
   complete: 'check',
   error: 'alert',
-  failed: 'alert',
+  failed: 'alert'
 }
 
 export default (Vue as VueConstructor<Vue & TableMixinBindings>).extend({
@@ -133,26 +144,26 @@ export default (Vue as VueConstructor<Vue & TableMixinBindings>).extend({
           align: 'start',
           sortable: true,
           value: 'created_at',
-          width: '200px',
+          width: '200px'
         },
         {
           text: 'Entry',
           width: '120px',
-          value: 'entry',
+          value: 'entry'
         },
         {
           text: 'Event',
           width: 500,
           sortable: false,
-          value: 'event',
+          value: 'event'
         },
         {
           text: 'Level',
           width: '120px',
-          value: 'level',
-        },
+          value: 'level'
+        }
       ]),
-      scan: {} as ScanAttributes,
+      scan: {} as ScanAttributes
     }
   },
   watch: {
@@ -162,13 +173,13 @@ export default (Vue as VueConstructor<Vue & TableMixinBindings>).extend({
           this.getLogs()
         })
       },
-      deep: true,
+      deep: true
     },
     entryFilter() {
       this.$nextTick(() => {
         this.getLogs()
       })
-    },
+    }
   },
   methods: {
     escapeHTML(data: unknown): unknown {
@@ -187,17 +198,17 @@ export default (Vue as VueConstructor<Vue & TableMixinBindings>).extend({
     },
     getDistinct(): void {
       ScanLogAPIService.distinct({ column: 'entry', id: this.scanID })
-        .then((res) => {
-          this.entryTypes = res.data.map((e) => e.entry)
+        .then(res => {
+          this.entryTypes = res.data.map(e => e.entry)
         })
         .catch(console.error)
     },
     getScan(): void {
       ScanAPIService.view({
         id: this.scanID,
-        eager: ['sources', 'sites'],
+        eager: ['sources', 'sites']
       })
-        .then((res) => {
+        .then(res => {
           this.init = true
           this.scan = res.data
         })
@@ -211,20 +222,21 @@ export default (Vue as VueConstructor<Vue & TableMixinBindings>).extend({
         entry: this.entryFilter,
         pageSize: this.itemsPerPage,
         search: this.search,
-        ...this.resolveOrder(),
+        ...this.resolveOrder()
       })
-        .then((res) => {
+        .then(res => {
           this.records = res.data.results
           this.total = res.data.total
+          window.scrollTo(0, 0)
         })
-        .catch((err) => {
+        .catch(err => {
           console.error(err)
         })
         .finally(() => (this.loading = false))
     },
     dataImage: (data: string) => `data:image/jpeg;base64, ${data}`,
     entryIcon: (entry: LogEntryTypes) =>
-      logTypeIcons[entry] ? logTypeIcons[entry] : 'alert-box',
+      logTypeIcons[entry] ? logTypeIcons[entry] : 'alert-box'
   },
   created() {
     this.scanID = this.$route.params.id
@@ -233,7 +245,8 @@ export default (Vue as VueConstructor<Vue & TableMixinBindings>).extend({
   },
   components: {
     VueJsonPretty,
-  },
+    ScanSummary
+  }
 })
 </script>
 


### PR DESCRIPTION
Adds scan summary API `GET /api/scans/:id/summary` to provide a roll-up of events and domains encountered during the scan.