### PR TITLE
feature(purge): purge jobs

### DIFF
--- a/backend/src/jobs/queues.ts
+++ b/backend/src/jobs/queues.ts
@@ -28,7 +28,7 @@ const scannerEventQueue = new Queue('scan-log-queue', {
   createClient,
 })
 
-const scannerPurge = new Queue('scanner-purge', {
+const localQueue = new Queue('local', {
   createClient,
 })
 
@@ -41,10 +41,10 @@ const alertQueue = new Queue<MerryMaker.EventResult>('alert-queue', {
 })
 
 export default {
+  localQueue,
   scannerScheduler,
   scannerQueue,
   scannerEventQueue,
-  scannerPurge,
   qtSecretRefresh,
   alertQueue,
 }

--- a/backend/src/models/seen_strings.ts
+++ b/backend/src/models/seen_strings.ts
@@ -14,26 +14,26 @@ export const Schema: { [prop: string]: ParamSchema } = {
   id: {
     description: 'ID of Seen String',
     type: 'string',
-    format: 'uuid',
+    format: 'uuid'
   },
   type: {
     description: 'Key type',
-    type: 'string',
+    type: 'string'
   },
   key: {
     description: 'Key value',
-    type: 'string',
+    type: 'string'
   },
   created_at: {
     description: 'Created Dated',
     type: 'string',
-    format: 'date-time',
+    format: 'date-time'
   },
   last_cached: {
     description: 'Date last seen in cache',
     type: 'string',
-    format: 'date-time',
-  },
+    format: 'date-time'
+  }
 }
 
 export default class SeenString extends BaseModel<SeenStringAttributes> {
@@ -49,7 +49,8 @@ export default class SeenString extends BaseModel<SeenStringAttributes> {
 
   $beforeInsert(): void {
     this.created_at = new Date()
-    this.last_cached = new Date()
+    this.last_cached =
+      this.last_cached !== undefined ? this.last_cached : new Date()
     this.id = uuidv4()
   }
 

--- a/backend/src/tests/seen_strings.service.test.ts
+++ b/backend/src/tests/seen_strings.service.test.ts
@@ -1,4 +1,5 @@
 import { resetDB } from './utils'
+import SeenString from '../models/seen_strings'
 import SeenStringFactory from './factories/seen_strings.factory'
 import SeenStringService from '../services/seen_string'
 
@@ -40,6 +41,30 @@ describe('Seen String Service', () => {
         .insert()
       const res = await SeenStringService.destroy(seenString.id)
       expect(res).toBe(1)
+    })
+  })
+  describe('purgeDBCache', () => {
+    let seenStringSet: SeenString[]
+    beforeAll(async () => {
+      const daysAgo = new Date()
+      daysAgo.setDate(daysAgo.getDate() - 3)
+      await SeenStringFactory.build({ key: 'oldone', last_cached: daysAgo })
+        .$query().insert()
+      await SeenStringFactory.build({ key: 'newone' })
+        .$query().insert()
+      await SeenStringFactory.build({ key: 'nullone', last_cached: null })
+        .$query().insert()
+      await SeenStringService.purgeDBCache(2)
+      seenStringSet = await SeenString.query()
+    })
+    it('deletes seen strings older than 2 days', () => {
+      expect(seenStringSet.every(s => s.key !== 'oldone')).toEqual(true)
+    })
+    it('deletes seen strings with null last_cached', () => {
+      expect(seenStringSet.every(s => s.key !== 'nullone')).toEqual(true)
+    })
+    it('does not delete seen strings under 2 days', () => {
+      expect(seenStringSet.some(s => s.key === 'newone')).toEqual(true)
     })
   })
 })


### PR DESCRIPTION
- Moves recurring purge jobs to a local bull.js queue
- Purge SeenString records with null or cached values last hit >= 6 months ago
- Purge scans active for an hour or more