### PR TITLE
breakfix(scanner): fixes node-fetch dep

### DIFF
--- a/scanner/package.json
+++ b/scanner/package.json
@@ -11,6 +11,7 @@
   "license": "Apache-2.0",
   "main": "index.js",
   "dependencies": {
+    "ajv": "^8.10.0",
     "async": "^3.2.0",
     "bull": "^3.29.0",
     "global": "^4.4.0",

--- a/scanner/src/lib/utils.ts
+++ b/scanner/src/lib/utils.ts
@@ -1,0 +1,30 @@
+import Ajv from 'ajv'
+
+import logger from '../loaders/logger'
+
+const ajv = new Ajv()
+
+/**
+ * isOfType
+ *
+ * Run-time type guard using AJV for schema validation
+ */
+export const isOfType = <T>(
+  value: unknown,
+  schema: string | boolean | Record<string, unknown>
+): value is T => {
+  ajv.validate(schema, value)
+  if (ajv.errors === null) {
+    return true
+  }
+  logger.error({
+    component: 'lib/utils#isOfType',
+    message: 'Failed Validation',
+    context: {
+      value,
+      schema: JSON.stringify(schema),
+    },
+    errors: ajv.errorsText()
+  })
+  throw new Error(`run-time type guard ${ajv.errorsText()}`)
+}

--- a/scanner/src/rules/yara.ts
+++ b/scanner/src/rules/yara.ts
@@ -6,9 +6,10 @@ import { config } from 'node-config-ts'
 import { js } from 'js-beautify'
 import YaraSync from '../lib/yara-sync'
 import * as MerryMaker from '@merrymaker/types'
-import fetch, { RequestInit } from 'node-fetch'
-import { Rule } from './base'
+import fetch, { RequestInit } from 'node-fetch-cjs'
+import { Rule, storeNameResponseSchema, StoreTypeResponse } from './base'
 import logger from '../loaders/logger'
+import { isOfType } from '../lib/utils'
 
 const oneHour = 1000 * 60 * 60
 
@@ -98,7 +99,7 @@ export class YaraRule extends Rule {
     return this.resolveEvent(res)
   }
 
-  async fetchRemoteSeenStrings(hash: string): Promise<{ store: string }> {
+  async fetchRemoteSeenStrings(hash: string): Promise<StoreTypeResponse> {
     const params = new URLSearchParams({
       key: hash,
       field: 'key',
@@ -110,7 +111,10 @@ export class YaraRule extends Rule {
         method: 'get',
       }
     )
-    return seenHash.json()
+    const res = await seenHash.json()
+    if (isOfType<StoreTypeResponse>(res, storeNameResponseSchema)) {
+      return res
+    }
   }
 
   async fetchFile(payload: MerryMaker.WebScriptEvent): Promise<string> {

--- a/yarn.lock
+++ b/yarn.lock
@@ -2587,6 +2587,16 @@ ajv@^8.0.0, ajv@^8.0.5, ajv@^8.6.2:
     require-from-string "^2.0.2"
     uri-js "^4.2.2"
 
+ajv@^8.10.0:
+  version "8.10.0"
+  resolved "https://registry.yarnpkg.com/ajv/-/ajv-8.10.0.tgz#e573f719bd3af069017e3b66538ab968d040e54d"
+  integrity sha512-bzqAEZOjkrUMl2afH8dknrq5KEk2SrwdBROR+vH1EKVQTqaUbJVPdc/gEdggTMM0Se+s+Ja4ju4TlNcStKl2Hw==
+  dependencies:
+    fast-deep-equal "^3.1.1"
+    json-schema-traverse "^1.0.0"
+    require-from-string "^2.0.2"
+    uri-js "^4.2.2"
+
 alphanum-sort@^1.0.0:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/alphanum-sort/-/alphanum-sort-1.0.2.tgz#97a1119649b211ad33691d9f9f486a8ec9fbe0a3"


### PR DESCRIPTION
- Fixes scanner failing to run due to `node-fetch-cjs` changes
- Adds TS type guard with AJV for runtime API response validation