### PR TITLE
improvement(sources): resync sources on startup

### DIFF
--- a/backend/src/jobs/index.ts
+++ b/backend/src/jobs/index.ts
@@ -3,6 +3,7 @@ import { createClient } from '../repos/redis'
 import logger from '../loaders/logger'
 import SiteService from '../services/site'
 import ScanService from '../services/scan'
+import SourceService from '../services/source'
 import AlertService from '../services/alert'
 import ScanLogService from '../services/scan_logs'
 import SeenStringService from '../services/seen_string'
@@ -17,6 +18,10 @@ const redisClient = createClient()
 
 Queues.scannerEventQueue.process(ScanLogService.work)
 ;(async () => {
+
+  logger.info('Syncing source cache')
+  const totalSync = await SourceService.syncCache()
+  logger.info(`Synced ${totalSync} sources with cache`)
   await Queues.scannerScheduler.isReady()
   await Queues.localQueue.isReady()
   await Queues.qtSecretRefresh.isReady()

--- a/backend/src/services/source.ts
+++ b/backend/src/services/source.ts
@@ -80,6 +80,17 @@ export async function cache(id: string): Promise<void> {
 }
 
 /**
+ * syncCache
+ *
+ * Syncs all Souces in cache
+ */
+export async function syncCache(): Promise<number> {
+  const sources = await Source.query()
+  await Promise.all(sources.map(source => cache(source.id)))
+  return sources.length
+}
+
+/**
  * clearCache
  *
  * Deletes source value from cache
@@ -114,5 +125,6 @@ export default {
   resolve,
   cache,
   getCache,
+  syncCache,
   clearCache,
 }


### PR DESCRIPTION
Adds service call to sync Sources with cache. Fixes issue when cache is cleared, or store is moved to another instance.

Will sync on startup in the mmkjobs services.