### PR TITLE
feat(util): strip non-ascii from scan_logs

### DIFF
--- a/backend/src/lib/utils.ts
+++ b/backend/src/lib/utils.ts
@@ -1,0 +1,7 @@
+/**
+ * stripJSONUnicode
+ *
+ * Removes unicode and null characters from a JSON object
+ */
+export const stripJSONUnicode = (obj: unknown) =>
+  JSON.parse(JSON.stringify(obj, null).replace(/([^ -~]|\\u0000)+/g, ''))

--- a/backend/src/models/scan_logs.ts
+++ b/backend/src/models/scan_logs.ts
@@ -1,6 +1,7 @@
 import { v4 as uuidv4 } from 'uuid'
 import MerryMaker from '@merrymaker/types'
 
+import { stripJSONUnicode } from '../lib/utils'
 import BaseModel from './base'
 import { ParamSchema } from 'aejo'
 
@@ -87,7 +88,9 @@ export default class ScanLog extends BaseModel<ScanLogAttributes> {
 
   $beforeInsert(): void {
     this.id = uuidv4()
-    this.event = JSON.parse(JSON.stringify(this.event, null).replace(/\0/g, ''))
+    if (this.event) {
+      this.event = stripJSONUnicode(this.event)
+    }
     if (this.created_at === null) {
       this.created_at = new Date()
     }

--- a/backend/src/tests/utils.test.ts
+++ b/backend/src/tests/utils.test.ts
@@ -1,0 +1,10 @@
+import { stripJSONUnicode } from '../lib/utils'
+
+describe('stripJSONUnicode', () => {
+  it('should strip non-ascii characters from POJOs', () => {
+    expect(stripJSONUnicode({ event: 'Öfoo' })).toEqual({ event: 'foo' })
+  })
+  it('should strip null characters from POJOs', () => {
+    expect(stripJSONUnicode({ event: 'foo\u0000' })).toEqual({ event: 'foo' })
+  })
+})


### PR DESCRIPTION
Stacked PR on #31 

Adds `./backend/src/utils` and stripJSONUnicode utility method to remove non-ascii and null characters from a POJO

Fixes issue where postgres inserts fail due to non-ascii/null characters found in the JSON value.

Adds test coverage for utility method