### PR TITLE
Fetch monitoring

### DIFF
--- a/scanner/src/rules/ioc.payload.ts
+++ b/scanner/src/rules/ioc.payload.ts
@@ -97,10 +97,8 @@ export class IOCPayloadRule extends Rule {
 
     const postData = payload.postData === undefined ? '' : payload.postData
 
-    // combine url, headers, and post data
-    const combined = `${payload.url} ${JSON.stringify(
-      payload.headers
-    )} ${postData}`
+    // combine url, headers, and post data and more things
+    const combined = `postData:${postData} ${JSON.stringify(payload)}`
     const combinedHash = crypto
       .createHash('sha256')
       .update(combined)

--- a/scanner/src/rules/ioc.payloads.yara
+++ b/scanner/src/rules/ioc.payloads.yara
@@ -21,3 +21,17 @@ rule ioc_payload_checkout_b64_cc {
   condition:
     all of them
 }
+
+
+rule fetch_abnormal_content {
+  meta:
+    description = "Detects a fetch to abnormal content: fonts, images, and css"
+    author = "Eric Brandel"
+  strings:
+    $resource = "resourceType\":\"fetch\""
+    $contentFont = "content-type\":\"font"
+    $contentImage = "content-type\":\"image"
+    $contentCSS = "content-type\":\"text/css"
+  condition:
+    $resource and any of ($content*) 
+}

--- a/scanner/src/tests/rules.ioc.payload.test.ts
+++ b/scanner/src/tests/rules.ioc.payload.test.ts
@@ -14,6 +14,11 @@ const testCases = [
     'https://example.com?cc=NDAxMjAwMDA3Nzc3Nzc3Nw',
     1,
   ],
+  [
+    'fetch_abnormal_content',
+    '"resourceType":"fetch" "content-type":"image',
+    1,
+  ],
 ]
 
 describe('IOC Payload Rules', () => {


### PR DESCRIPTION
Updated ioc.payload to allow for rules to be written targeting a broader range of payload data, including the entire payload in the 

The new fetch_abnormal_content rule is an example of this, which looks for unexpected content being fetched.