### PR TITLE
improvement(ui): use notifymixin over console

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -16,7 +16,6 @@
     "prismjs": "^1.24.1",
     "vue": "^2.6.11",
     "vue-class-component": "^7.2.3",
-    "vue-cli-plugin-vuetify": "~2.4.5",
     "vue-json-pretty": "^1.8.1",
     "vue-prism-editor": "^1.2.2",
     "vue-property-decorator": "^8.4.2",
@@ -49,7 +48,7 @@
     "sass": "~1.32",
     "sass-loader": "^10.1.1",
     "typescript": "~4.5.5",
-    "vue-cli-plugin-vuetify": "~2.0.7",
+    "vue-cli-plugin-vuetify": "~2.4.5",
     "vue-template-compiler": "^2.6.11",
     "vuetify-loader": "^1.3.0"
   },

--- a/frontend/src/views/dashboard/Dashboard.vue
+++ b/frontend/src/views/dashboard/Dashboard.vue
@@ -116,6 +116,8 @@ import AlertAPIService, { AlertAttributes } from '@/services/alerts'
 import ScanAPIServce, { ScanAttributes } from '@/services/scans'
 import QueueService, { Queues } from '@/services/queues'
 
+import NotifyMixin from '@/mixins/notify'
+
 let pollingInterval: number
 
 interface DashboardAttributes {
@@ -130,6 +132,7 @@ interface DashboardAttributes {
 
 export default (Vue as VueConstructor<Vue & DashboardAttributes>).extend({
   name: 'DashboardView',
+  mixins: [NotifyMixin],
   data() {
     return {
       alertsLoading: false,
@@ -167,7 +170,7 @@ export default (Vue as VueConstructor<Vue & DashboardAttributes>).extend({
           this.queues = res.data
           this.queuesLoading = false
         })
-        .catch(console.error)
+        .catch(this.errorHandler)
     },
     getScans() {
       this.scansLoading = true
@@ -183,7 +186,7 @@ export default (Vue as VueConstructor<Vue & DashboardAttributes>).extend({
         .then((res) => {
           this.scans = res.data.results
         })
-        .catch(console.error)
+        .catch(this.errorHandler)
     },
     getAll() {
       this.getAlerts()

--- a/frontend/src/views/dashboard/IOCs.vue
+++ b/frontend/src/views/dashboard/IOCs.vue
@@ -72,9 +72,10 @@ import IocAPIService, { IocAttributes } from '../../services/iocs'
 import Confirm, { ConfirmDialog } from '../../components/utils/Confirm.vue'
 
 import TableMixin, { TableMixinBindings } from '@/mixins/table'
+import NotifyMixin from '@/mixins/notify'
 
 export default (Vue as VueConstructor<Vue & TableMixinBindings>).extend({
-  mixins: [TableMixin],
+  mixins: [TableMixin, NotifyMixin],
   name: 'IOCsView',
   data() {
     return {
@@ -84,28 +85,28 @@ export default (Vue as VueConstructor<Vue & TableMixinBindings>).extend({
           text: 'Value',
           align: 'start',
           sortable: true,
-          value: 'value',
+          value: 'value'
         },
         {
           text: 'Type',
           sortable: true,
-          value: 'type',
+          value: 'type'
         },
         {
           text: 'Enabled',
-          value: 'enabled',
+          value: 'enabled'
         },
         {
           text: 'Created',
-          value: 'created_at',
+          value: 'created_at'
         },
         {
           text: 'Actions',
           value: 'actions',
-          sortable: false,
-        },
+          sortable: false
+        }
       ]),
-      records: [] as IocAttributes[],
+      records: [] as IocAttributes[]
     }
   },
   watch: {
@@ -115,15 +116,15 @@ export default (Vue as VueConstructor<Vue & TableMixinBindings>).extend({
           this.list()
         })
       },
-      deep: true,
-    },
+      deep: true
+    }
   },
   methods: {
     async list() {
       const res = await IocAPIService.list({
         page: this.page,
         pageSize: this.itemsPerPage,
-        ...this.resolveOrder(),
+        ...this.resolveOrder()
       })
       this.loading = false
       this.records = res.data.results
@@ -134,24 +135,20 @@ export default (Vue as VueConstructor<Vue & TableMixinBindings>).extend({
       const dialog = (this.$refs.confirm as unknown) as ConfirmDialog
       const res = await dialog.open('Delete', 'Are you sure?', {
         color: 'red',
-        width: 350,
+        width: 350
       })
       if (res) {
-        try {
-          await IocAPIService.destroy({ id })
-          this.records.forEach((record, i) => {
-            if (record.id === id) {
-              this.records.splice(i, 1)
-            }
+        await IocAPIService.destroy({ id })
+          .then(() => {
+            this.info({ title: 'IOCs', body: 'IOC Deletd' })
+            this.list()
           })
-        } catch (e) {
-          console.error(e)
-        }
+          .catch(this.errorHandler)
       }
-    },
+    }
   },
   components: {
-    Confirm,
-  },
+    Confirm
+  }
 })
 </script>

--- a/frontend/src/views/dashboard/Secrets.vue
+++ b/frontend/src/views/dashboard/Secrets.vue
@@ -42,7 +42,7 @@
                   @click="
                     $router.push({
                       path: '/secrets/edit',
-                      query: { id: item.id },
+                      query: { id: item.id }
                     })
                   "
                 >
@@ -94,28 +94,28 @@ export default (Vue as VueConstructor<Vue & TableMixinBindings>).extend({
           text: 'Name',
           align: 'start',
           sortable: true,
-          value: 'name',
+          value: 'name'
         },
         {
           text: 'Type',
           sortable: true,
-          value: 'type',
+          value: 'type'
         },
         {
           text: 'Created',
-          value: 'created_at',
+          value: 'created_at'
         },
         {
           text: 'Updated',
-          value: 'updated_at',
+          value: 'updated_at'
         },
         {
           text: 'Actions',
           value: 'actions',
-          sortable: false,
-        },
+          sortable: false
+        }
       ]),
-      records: [] as SecretAttributes[],
+      records: [] as SecretAttributes[]
     }
   },
   watch: {
@@ -125,8 +125,8 @@ export default (Vue as VueConstructor<Vue & TableMixinBindings>).extend({
           this.list()
         })
       },
-      deep: true,
-    },
+      deep: true
+    }
   },
   methods: {
     async list() {
@@ -135,7 +135,7 @@ export default (Vue as VueConstructor<Vue & TableMixinBindings>).extend({
         page: this.page,
         eager: ['sources'],
         pageSize: this.itemsPerPage,
-        ...this.resolveOrder(),
+        ...this.resolveOrder()
       })
       this.loading = false
       this.records = res.data.results
@@ -146,21 +146,20 @@ export default (Vue as VueConstructor<Vue & TableMixinBindings>).extend({
       const dialog = (this.$refs.confirm as unknown) as ConfirmDialog
       const res = await dialog.open('Delete', 'Are you sure?', {
         color: 'red',
-        width: 350,
+        width: 350
       })
       if (res) {
-        try {
-          await SecretAPIService.destroy({ id })
-          this.info({ title: 'Secrets', body: 'Secret Deleted' })
-          await this.list()
-        } catch (e) {
-          console.error(e)
-        }
+        await SecretAPIService.destroy({ id })
+          .then(() => {
+            this.info({ title: 'Secrets', body: 'Secret Deleted' })
+            this.list()
+          })
+          .then(this.errorHandler)
       }
-    },
+    }
   },
   components: {
-    Confirm,
-  },
+    Confirm
+  }
 })
 </script>

--- a/frontend/src/views/dashboard/Sources.vue
+++ b/frontend/src/views/dashboard/Sources.vue
@@ -105,23 +105,23 @@ export default (Vue as VueConstructor<Vue & TableMixinBindings>).extend({
           text: 'Name',
           align: 'start',
           sortable: true,
-          value: 'name',
+          value: 'name'
         },
         {
           text: 'Scans',
-          value: 'scans.length',
+          value: 'scans.length'
         },
         {
           text: 'Created',
-          value: 'created_at',
+          value: 'created_at'
         },
         {
           text: 'Actions',
           value: 'actions',
-          sortable: false,
-        },
+          sortable: false
+        }
       ]),
-      records: [] as SourceAttributes[],
+      records: [] as SourceAttributes[]
     }
   },
   watch: {
@@ -131,11 +131,11 @@ export default (Vue as VueConstructor<Vue & TableMixinBindings>).extend({
           this.list()
         })
       },
-      deep: true,
+      deep: true
     },
     showTest() {
       this.list()
-    },
+    }
   },
   methods: {
     async list() {
@@ -145,7 +145,7 @@ export default (Vue as VueConstructor<Vue & TableMixinBindings>).extend({
         pageSize: this.itemsPerPage,
         eager: ['scans'],
         no_test: !this.showTest,
-        ...this.resolveOrder(),
+        ...this.resolveOrder()
       })
       this.loading = false
       this.records = res.data.results
@@ -159,20 +159,20 @@ export default (Vue as VueConstructor<Vue & TableMixinBindings>).extend({
       const dialog = (this.$refs.confirm as unknown) as ConfirmDialog
       const res = await dialog.open('Delete', 'Are you sure?', {
         color: 'red',
-        width: 350,
+        width: 350
       })
       if (res) {
-        try {
-          await SourceAPIService.destroy({ id })
-          this.info({ title: 'Source', body: 'Source Deleted' })
-        } catch (e) {
-          console.error(e)
-        }
+        await SourceAPIService.destroy({ id })
+          .then(() => {
+            this.info({ title: 'Source', body: 'Source Deleted' })
+            this.list()
+          })
+          .catch(this.errorHandler)
       }
-    },
+    }
   },
   components: {
-    Confirm,
-  },
+    Confirm
+  }
 })
 </script>


### PR DESCRIPTION
Stacked PR on #44 

- Replaces `console.log` with NotifyMixin where services return an error
- Prettified several components