### PR TITLE
feat(alerts-api): adds aggregation route

### DIFF
--- a/backend/src/api/routes/alerts/agg.ts
+++ b/backend/src/api/routes/alerts/agg.ts
@@ -1,0 +1,63 @@
+import { AsyncGet, QueryParam } from 'aejo'
+import { Request, Response, NextFunction } from 'express'
+import sub from 'date-fns/sub'
+import AlertService from '../../../services/alert'
+
+export default AsyncGet({
+  tags: ['alerts'],
+  description: 'Alert Aggregation',
+  parameters: [
+    QueryParam({
+      name: 'interval_hours',
+      description: 'Group alerts by hours',
+      schema: {
+        type: 'number',
+        minimum: 1,
+        default: 1
+      }
+    }),
+    QueryParam({
+      name: 'start_time',
+      description: 'Start range',
+      schema: {
+        type: 'string',
+        format: 'date-time',
+        default: 'one week ago'
+      }
+    }),
+    QueryParam({
+      name: 'end_time',
+      description: 'Start range',
+      schema: {
+        type: 'string',
+        format: 'date-time',
+        default: 'now'
+      }
+    })
+  ],
+  middleware: [
+    async (req: Request, res: Response, next: NextFunction): Promise<void> => {
+      const { interval_hours, start_time, end_time } = req.query
+      let local_interval = 1
+      if (interval_hours && typeof interval_hours == 'number') {
+        local_interval = interval_hours
+      }
+      let local_start_time = sub(new Date(), { weeks: 1 })
+      if (start_time) {
+        local_start_time = new Date(local_start_time)
+      }
+      let local_end_time = new Date()
+      if (end_time && typeof end_time == 'string') {
+        local_end_time = new Date(end_time)
+      }
+      const agg = await AlertService.dateHist({
+        starttime: local_start_time,
+        endtime: local_end_time,
+        interval: local_interval
+      })
+      res.set('Cache-Control', 'no-store')
+      res.status(200).send({ rows: agg.rows })
+      next()
+    }
+  ]
+})

--- a/backend/src/api/routes/alerts/index.ts
+++ b/backend/src/api/routes/alerts/index.ts
@@ -8,6 +8,7 @@ import listRoute from './list'
 import viewRoute from './view'
 import deleteRoute from './delete'
 import distinctRoute from './distinct'
+import aggRoute from './agg'
 
 const AdminScope = AuthPathOp(Scope(Authorized, 'admin'))
 
@@ -15,6 +16,7 @@ export default (router: Router): { paths: PathItem[]; router: Router } =>
   Route(
     router,
     Path('/', AuthScope(listRoute)),
+    Path('/agg', AuthScope(aggRoute)),
     Path(`/:id(${uuidFormat})`, AuthScope(viewRoute), AdminScope(deleteRoute)),
     Path('/distinct', AuthScope(distinctRoute))
   )

--- a/backend/src/tests/alert.service.test.ts
+++ b/backend/src/tests/alert.service.test.ts
@@ -1,0 +1,77 @@
+import AlertService from '../services/alert'
+import AlertFactory from './factories/alert.factory'
+import ScanFactory from './factories/scans.factory'
+import SiteFactory from './factories/sites.factory'
+import SourceFactory from './factories/sources.factory'
+import { resetDB } from './utils'
+import sub from 'date-fns/sub'
+
+describe('Alert Service', () => {
+  beforeEach(async () => {
+    await resetDB()
+  })
+  describe('dateHist', () => {
+    it('should return a grouping of alerts by hour', async () => {
+      const seedSource = await SourceFactory.build()
+        .$query()
+        .insert()
+        .returning('*')
+      const seedSite = await SiteFactory.build({ source_id: seedSource.id })
+        .$query()
+        .insert()
+        .returning('*')
+      const seedScan = await ScanFactory.build({
+        site_id: seedSite.id,
+        source_id: seedSource.id
+      })
+        .$query()
+        .insert()
+        .returning('*')
+      // current hour
+      await AlertFactory.build({
+        site_id: seedSite.id,
+        scan_id: seedScan.id
+      })
+        .$query()
+        .insert()
+        .returning('*')
+      // previous hour
+      await AlertFactory.build({
+        site_id: seedSite.id,
+        scan_id: seedScan.id,
+        created_at: sub(new Date(), { hours: 1 })
+      })
+        .$query()
+        .insert()
+        .returning('*')
+      // previous hour
+      await AlertFactory.build({
+        site_id: seedSite.id,
+        scan_id: seedScan.id,
+        created_at: sub(new Date(), { hours: 1 })
+      })
+        .$query()
+        .insert()
+        .returning('*')
+      // two hours ago
+      await AlertFactory.build({
+        site_id: seedSite.id,
+        scan_id: seedScan.id,
+        created_at: sub(new Date(), { hours: 2 })
+      })
+        .$query()
+        .insert()
+        .returning('*')
+      const res = await AlertService.dateHist({
+        starttime: sub(new Date(), { hours: 3 }),
+        endtime: new Date(),
+        interval: 1
+      })
+      expect(res.rows.length).toBe(4)
+      expect(res.rows[0].count).toBe(1)
+      expect(res.rows[1].count).toBe(2)
+      expect(res.rows[2].count).toBe(1)
+      expect(res.rows[3].count).toBe(0)
+    })
+  })
+})


### PR DESCRIPTION
Adds `GET /api/v1/alerts/agg` route to generate and return a histogram of alerts based on interval and date ranges.