### PR TITLE
feat: allow-list referrer handling

### DIFF
--- a/backend/src/api/routes/allow_list/cache.ts
+++ b/backend/src/api/routes/allow_list/cache.ts
@@ -16,7 +16,7 @@ export default AsyncGet({
       // if not in cache, check the DB
       if (!hit.has) {
         const dbHit = await AllowListService.findOne({
-          type: type as AllowListType,
+          type: typeof AllowListType,
           key,
         })
         if (dbHit) {

--- a/backend/src/models/allow_list.ts
+++ b/backend/src/models/allow_list.ts
@@ -3,16 +3,18 @@ import BaseModel from './base'
 import { v4 as uuidv4 } from 'uuid'
 import { ParamSchema } from 'aejo'
 
-export type AllowListType =
-  | 'fqdn'
-  | 'ip'
-  | 'literal'
-  | 'ioc-payload-domain'
-  | 'google-analytics'
+export const AllowListType = [
+  'fqdn',
+  'ip',
+  'literal',
+  'ioc-payload-domain',
+  'google-analytics',
+  'referrer'
+]
 
 export interface AllowListAttributes {
   id?: string
-  type: AllowListType
+  type: typeof AllowListType[number]
   key: string
   created_at?: Date
   updated_at?: Date
@@ -22,28 +24,28 @@ export const Schema: { [prop: string]: ParamSchema } = {
   id: {
     description: 'ID of Allow List',
     type: 'string',
-    format: 'uuid',
+    format: 'uuid'
   },
   type: {
     description: 'Key type',
     type: 'string',
-    enum: ['fqdn', 'ip', 'literal', 'ioc-payload-domain', 'google-analytics'],
+    enum: AllowListType
   },
   key: {
     description: 'Matching key pattern',
     type: 'string',
-    format: 'regex',
+    format: 'regex'
   },
   created_at: {
     description: 'Created Date',
     type: 'string',
-    format: 'date-time',
+    format: 'date-time'
   },
   updated_at: {
     description: 'Updated Date',
     type: 'string',
-    format: 'date-time',
-  },
+    format: 'date-time'
+  }
 }
 
 export default class AllowList extends BaseModel<AllowListAttributes> {
@@ -80,27 +82,5 @@ export default class AllowList extends BaseModel<AllowListAttributes> {
 
   static build(o: Partial<AllowListAttributes>): AllowList {
     return AllowList.fromJson(o)
-  }
-
-  static get jsonSchema(): JSONSchema {
-    return {
-      type: 'object',
-      required: ['type', 'key'],
-      properties: {
-        type: {
-          type: 'string',
-          enum: [
-            'fqdn',
-            'ip',
-            'literal',
-            'ioc-payload-domain',
-            'google-analytics',
-          ],
-        },
-        key: {
-          type: 'string',
-        },
-      },
-    }
   }
 }

--- a/backend/src/models/allow_list.ts
+++ b/backend/src/models/allow_list.ts
@@ -1,4 +1,3 @@
-import { JSONSchema } from 'objection'
 import BaseModel from './base'
 import { v4 as uuidv4 } from 'uuid'
 import { ParamSchema } from 'aejo'


### PR DESCRIPTION
- Adds `referrer` allow-list type
- Updates scanner/unknown-domain rule to check `referrer` allow-list type

Significantly reduces noise for unknown domain alerts from trusted pixel trackers.

Stacked PR on #51 