### PR TITLE
Fix config import to use node-config-ts

### DIFF
--- a/scanner/src/rules/base.ts
+++ b/scanner/src/rules/base.ts
@@ -1,5 +1,5 @@
 import MerryMakerTypes from '@merrymaker/types'
-import { config } from 'node-config'
+import { config } from 'node-config-ts'
 
 import fetch from 'node-fetch-cjs'
 import { isOfType } from '../lib/utils'


### PR DESCRIPTION
`scanner` won't grab the config data and start with this build -- updated it to use node-config-ts like the rest of the project and it works now. 