### PR TITLE
enrichment(rules): provide context for enrichments

### DIFF
--- a/backend/package.json
+++ b/backend/package.json
@@ -49,7 +49,7 @@
     "connect-redis": "^5.0.0",
     "cookie-parser": "^1.4.5",
     "date-fns": "^2.16.1",
-    "express": "^4.17.1",
+    "express": "^4.17.3",
     "express-session": "^1.17.1",
     "fp-ts": "^2.8.2",
     "helmet": "^3.23.3",

--- a/backend/src/alerts/base.ts
+++ b/backend/src/alerts/base.ts
@@ -7,6 +7,7 @@ export interface AlertEvent {
   scan_id: string
   message: string
   details: string
+  body?: object
 }
 
 export interface AlertSinkBase {

--- a/backend/src/alerts/kafka.ts
+++ b/backend/src/alerts/kafka.ts
@@ -11,6 +11,7 @@ export interface AlertV1 {
   rule: string
   level: AlertEvent['type']
   description: string
+  body: object
   cause?: string
   url?: string
   scanName?: string
@@ -24,6 +25,7 @@ const toAlertV1 = (evt: AlertEvent): AlertV1 => ({
   rule: evt.name,
   level: evt.type,
   description: evt.message,
+  body: evt.body,
   scanUrl: `${config.server.uri}/scans/${evt.scan_id}`,
 })
 
@@ -56,7 +58,7 @@ export const init = (
   const kafka = new Kafka({
     brokers: [`${kafkaConfig.host}:${kafkaConfig.port}`],
     clientId: kafkaConfig.clientID,
-    ssl: kafkaSSLOptions,
+    ssl: kafkaSSLOptions
   })
 
   const kafkaProducer = kafka.producer()
@@ -65,13 +67,12 @@ export const init = (
     await kafkaProducer.connect()
     const messages = [
       {
-        key: 'msg',
         value: JSON.stringify(toAlertV1(evt)),
       },
     ]
     await kafkaProducer.send({
       topic: kafkaConfig.topic,
-      messages,
+      messages
     })
     await kafkaProducer.disconnect()
     logger.info({

--- a/backend/src/services/alert.ts
+++ b/backend/src/services/alert.ts
@@ -101,6 +101,7 @@ function toAlertEvent(evt: MerryMaker.EventResult): AlertEvent {
     scan_id: evt.scan_id,
     message,
     details,
+    body: evt.event,
   }
 }
 

--- a/scanner/config/env/test.json
+++ b/scanner/config/env/test.json
@@ -1,0 +1,5 @@
+{
+  "transport": {
+    "http": "http://localhost:3031"
+  }
+}

--- a/scanner/package.json
+++ b/scanner/package.json
@@ -26,15 +26,17 @@
     "yara": "https://github.com/S03D4-164/node-yara.git#dev"
   },
   "devDependencies": {
-    "@merrymaker/types": "^1.0.6",
+    "@merrymaker/types": "^1.0.10",
     "@types/bull": "^3.15.0",
     "@types/jest": "^26.0.19",
+    "@types/nock": "^11.1.0",
     "@types/node": "^14.0.27",
     "@types/node-fetch": "^2.5.7",
     "@typescript-eslint/eslint-plugin": "^5.3.0",
     "@typescript-eslint/parser": "^5.3.0",
     "eslint": "^8.1.0",
     "jest": "^26.2.2",
+    "nock": "^13.2.4",
     "ts-jest": "^26.4.4",
     "ts-node": "^8.10.2",
     "typescript": "^4.4.4"

--- a/scanner/src/lib/scan-event-handler.ts
+++ b/scanner/src/lib/scan-event-handler.ts
@@ -65,7 +65,7 @@ export default class ScanEventHandler {
   }
   async process(rj: RuleJobData): Promise<RuleAlert[]> {
     if (this.byName.has(rj.rule)) {
-      return this.byName.get(rj.rule).process(rj.event.payload)
+      return this.byName.get(rj.rule).process(rj.event)
     } else {
       return Promise.reject(`no matching rule for ${rj.rule}`)
     }

--- a/scanner/src/rules/base.ts
+++ b/scanner/src/rules/base.ts
@@ -1,8 +1,10 @@
-import MerryMakerTypes from '@merrymaker/types'
-import { config } from 'node-config'
+import fetch from 'node-fetch'
+import MerryMakerTypes, { ScanEvent } from '@merrymaker/types'
+import LRUCache from 'lru-native2'
+import { config } from 'node-config-ts'
 
-import fetch from 'node-fetch-cjs'
 import { isOfType } from '../lib/utils'
+import logger from '../loaders/logger'
 
 const allowListURL = `${config.transport.http}/api/allow_list`
 
@@ -35,11 +37,10 @@ export type StoreTypeResponse = {
 }
 
 export abstract class Rule {
+  event: ScanEvent
   alertResults: MerryMakerTypes.RuleAlert[]
   constructor(protected readonly options: MerryMakerTypes.RuleAlert) {}
-  abstract process(
-    evt: MerryMakerTypes.ScanEventPayload
-  ): Promise<MerryMakerTypes.RuleAlert[]>
+  abstract process(scanEvent: ScanEvent): Promise<MerryMakerTypes.RuleAlert[]>
   get ruleDetails(): MerryMakerTypes.RuleAlert {
     return this.options
   }
@@ -111,5 +112,113 @@ export abstract class Rule {
     if (isOfType<StoreTypeResponse>(res, storeNameResponseSchema)) {
       return res
     }
+  }
+
+  /**
+   * fetchSeenStrings
+   *
+   * read-only call to check if seen_string exists in remote cache
+   */
+  async fetchSeenStrings(
+    key: string,
+    type: string
+  ): Promise<StoreTypeResponse> {
+    const url = new URL(`${config.transport.http}/api/seen_strings/_cache`)
+    url.search = new URLSearchParams({
+      key,
+      type
+    }).toString()
+    // fetch cache
+    const seenReq = await fetch(url, {
+      method: 'get',
+      headers: { 'Content-Type': 'application/json' }
+    })
+    const res = await seenReq.json()
+    if (isOfType<StoreTypeResponse>(res, storeNameResponseSchema)) {
+      return res
+    }
+  }
+
+  /**
+   * isAllowed
+   *
+   * check to see if key/value is found in remote allow list
+   *
+   * updates `cache` if found
+   */
+  async isAllowed(options: {
+    value: string
+    key: string
+    cache: LRUCache<number>
+  }): Promise<boolean> {
+    let cacheKey = options.value
+    if (options.cache.get(cacheKey)) {
+      logger.info({
+        module: 'rules/base',
+        method: 'isAllowed',
+        result: `${options.key}/${cacheKey} found in cache`
+      })
+      return true
+    }
+    const allowed = await this.fetchRemoteAllowList(cacheKey, options.key)
+    if (allowed.total > 0) {
+      logger.info({
+        module: 'rules/base',
+        method: 'isAllowed',
+        result: `${options.key}/${cacheKey} found in remote allow-list`
+      })
+      if (this.event.test) {
+        cacheKey = `${cacheKey}|${this.event.scanID}`
+      }
+      options.cache.set(cacheKey, 1)
+      return true
+    }
+    return false
+  }
+
+  /**
+   * wasSeen
+   *
+   * checks if key/value pair has already been seen in local and remote caches
+   *
+   * scopes test scans by scanID in local cache
+   *
+   * wrapper around `fetchSeenStrings` and `bumpRemoteCache`
+   */
+  async wasSeen(options: {
+    value: string
+    key: string
+    cache: LRUCache<number>
+  }): Promise<StoreTypeResponse> {
+    let seenString = options.value
+    if (this.event.test) {
+      seenString = `${seenString}|${this.event.scanID}`
+    }
+    if (options.cache.get(options.value) === 1) {
+      logger.info({
+        module: 'rules/base',
+        method: 'wasSeen',
+        result: `${options.key}/${seenString} found in cache`
+      })
+      return { store: 'local' }
+    }
+    let seenData: StoreTypeResponse
+    if (this.event.test) {
+      if (options.cache.get(seenString) === 1) {
+        logger.info({
+          module: 'rules/base',
+          method: 'wasSeen/test',
+          result: `${options.key}/${seenString} found in test cache`
+        })
+        return { store: 'local' }
+      }
+      // do not update remote cache for tests
+      seenData = await this.fetchSeenStrings(options.value, options.key)
+    } else {
+      // Check remote cache and update (read-through)
+      seenData = await this.bumpRemoteCache(options.value, options.key)
+    }
+    options.cache.set(seenString, 1)
+    return seenData
   }
 }

--- a/scanner/src/rules/google-analytics.ts
+++ b/scanner/src/rules/google-analytics.ts
@@ -28,8 +28,9 @@ const seenTrackingIDCache = new LRUCache({
 export class GoogleAnalyticsRule extends Rule {
   alertResults: MerryMaker.RuleAlert[]
   async process(
-    payload: MerryMaker.WebRequestEvent
+    scanEvent: MerryMaker.ScanEvent
   ): Promise<MerryMaker.RuleAlert[]> {
+    const payload = scanEvent.payload as MerryMaker.WebRequestEvent
     this.alertResults = []
     const res: MerryMaker.RuleAlert = {
       name: this.options.name,

--- a/scanner/src/rules/html-snapshot.ts
+++ b/scanner/src/rules/html-snapshot.ts
@@ -35,8 +35,9 @@ const snapshotHashCache = new LRUCache({
 export class HtmlSnapshotRule extends Rule {
   alertResults: MerryMaker.RuleAlert[]
   async process(
-    payload: MerryMaker.HtmlSnapshot
+    scanEvent: MerryMaker.ScanEvent
   ): Promise<MerryMaker.RuleAlert[]> {
+    const payload = scanEvent.payload as MerryMaker.HtmlSnapshot
     this.alertResults = []
     const res: MerryMaker.RuleAlert = {
       name: this.options.name,

--- a/scanner/src/rules/ioc.domain.ts
+++ b/scanner/src/rules/ioc.domain.ts
@@ -31,8 +31,10 @@ const domainAllowListCache = new LRUCache({
 export class IOCDomainRule extends Rule {
   alertResults: MerryMaker.RuleAlert[]
   async process(
-    payload: MerryMaker.WebRequestEvent
+    scanEvent: MerryMaker.ScanEvent
   ): Promise<MerryMaker.RuleAlert[]> {
+    this.event = scanEvent
+    const payload = scanEvent.payload as MerryMaker.WebRequestEvent
     this.alertResults = []
     const res: MerryMaker.RuleAlert = {
       name: this.options.name,

--- a/scanner/src/rules/ioc.payload.ts
+++ b/scanner/src/rules/ioc.payload.ts
@@ -41,8 +41,9 @@ const iocPayloadCache = new LRUCache({
 export class IOCPayloadRule extends Rule {
   alertResults: MerryMaker.RuleAlert[]
   async process(
-    payload: MerryMaker.WebRequestEvent
+    scanEvent: MerryMaker.ScanEvent
   ): Promise<MerryMaker.RuleAlert[]> {
+    const payload = scanEvent.payload as MerryMaker.WebRequestEvent
     this.alertResults = []
     const res: MerryMaker.RuleAlert = {
       name: this.options.name,

--- a/scanner/src/rules/unknown-domain.ts
+++ b/scanner/src/rules/unknown-domain.ts
@@ -7,14 +7,14 @@ import { IResult } from 'tldts-core'
 
 const oneHour = 1000 * 60 * 60
 
-const domainAllowListCache = new LRUCache({
+export const domainAllowListCache = new LRUCache<number>({
   maxElements: 1000,
   maxAge: oneHour,
   size: 50,
   maxLoadFactor: 2.0
 })
 
-const seenDomainCache = new LRUCache({
+export const seenDomainCache = new LRUCache<number>({
   maxElements: 10000,
   maxAge: oneHour,
   size: 1000,
@@ -23,86 +23,111 @@ const seenDomainCache = new LRUCache({
 
 export class UnknownDomainRule extends Rule {
   alertResults: MerryMaker.RuleAlert[]
+  payload: MerryMaker.WebRequestEvent
+  payloadURL: IResult
   async process(
-    payload: MerryMaker.WebRequestEvent
+    scanEvent: MerryMaker.ScanEvent
   ): Promise<MerryMaker.RuleAlert[]> {
+    this.event = scanEvent
+
+    this.payload = scanEvent.payload as MerryMaker.WebRequestEvent
     this.alertResults = []
     const res: MerryMaker.RuleAlert = {
       name: this.options.name,
       alert: false,
       level: this.options.level,
-      context: { url: payload.url }
+      context: { url: this.payload.url }
     }
 
     // Handle invalid URLs
-    let payloadURL: IResult
     try {
-      payloadURL = parse(payload.url)
+      this.payloadURL = parse(this.payload.url)
     } catch (e) {
-
+      res.message = `failed to parse URL ${e.message}`
       return this.resolveEvent(res)
     }
 
-    if (payloadURL.domain === null) {
-      res.message = `missing / empty domain for payload (${payload.url})`
+    if (this.payloadURL.domain === null) {
+      res.message = `missing / empty domain for payload (${this.payload.url})`
       return this.resolveEvent(res)
     }
 
     // Check allow_list cache
-    if (domainAllowListCache.get(payloadURL.domain)) {
-      res.message = `allow-listed (cache) ${payloadURL.domain}`
-      return this.resolveEvent(res)
-    }
+    const allowedDomain = await this.isAllowed({
+      value: this.payloadURL.domain,
+      key: 'fqdn',
+      cache: domainAllowListCache
+    })
 
-    const whiteList = await this.fetchRemoteAllowList(payloadURL.domain, 'fqdn')
-
-    // Checkout backend transport
-    if (whiteList.total > 0) {
-      res.message = `allow-listed (DB) ${payloadURL.domain}`
-      domainAllowListCache.set(payloadURL.domain, 1)
+    if (allowedDomain) {
+      res.message = `domain allow-listed ${this.payloadURL.domain}`
       return this.resolveEvent(res)
     }
 
     // Check if referer allows pass through
-    if (payload.headers.referer) {
-      const refererURL = parse(payload.headers.referer)
-      const lruKey = `${payloadURL.domain}|${refererURL.domain}`
-      // check local cache before checking remote allow-list
-      if (domainAllowListCache.get(lruKey)) {
-        res.message = `allow-listed / referer (cache) ${lruKey}`
-        return this.resolveEvent(res)
-      }
-      const allowedReferrer = await this.fetchRemoteAllowList(
-        refererURL.domain,
-        'referrer'
-      )
-      if (allowedReferrer.total > 0) {
-        res.message = `allow-listed / referer (${refererURL.domain}) (DB)`
-        domainAllowListCache.set(lruKey, 1)
+    if (this.payload.headers?.referer) {
+      const { allowed, message } = await this.allowedReferrer()
+      if (allowed) {
+        res.message = message
         return this.resolveEvent(res)
       }
     }
 
-    // Check full hostname in seen domain cache
-    if (seenDomainCache.get(payloadURL.hostname) === 1) {
-      res.message = `seen hostname (cache) ${payloadURL.hostname}`
-      return this.resolveEvent(res)
-    }
+    const seenDomain = await this.wasSeen({
+      value: this.payloadURL.hostname,
+      key: 'domain',
+      cache: seenDomainCache
+    })
 
-    // Check remote cache
-    const seenData = await this.bumpRemoteCache(payloadURL.hostname, 'domain')
-
-    // cache the result
-    seenDomainCache.set(payloadURL.hostname, 1)
     // Alert if domain was not found in any store
-    if (seenData.store === 'none') {
+    if (seenDomain.store === 'none') {
       res.alert = true
-      res.message = `${payloadURL.hostname} unknown`
+      res.message = `${this.payloadURL.hostname} unknown`
     }
 
-    res.context.domain = payloadURL.hostname
+    // attach domain
+    res.context.domain = this.payloadURL.hostname
 
     return this.resolveEvent(res)
+  }
+
+  /**
+   * allowedReferrer
+   *
+   * checks if request comes from an allowed referrer
+   *
+   * checks local `domainAllowListCache` then remote allow-list if not found
+   *
+   * updates `domainAllowListCache` if found in remote allow-list
+   *
+   * scopes test scans by `scanID`
+   */
+  async allowedReferrer(): Promise<{ allowed: boolean; message?: string }> {
+    const refererURL = parse(this.payload.headers.referer)
+    let lruKey = `${this.payloadURL.domain}|${refererURL.domain}`
+    // check local cache before checking remote allow-list
+    if (domainAllowListCache.get(lruKey)) {
+      return {
+        allowed: true,
+        message: `allow-listed / referer (cache) ${lruKey}`
+      }
+    }
+    const allowedReferrer = await this.fetchRemoteAllowList(
+      refererURL.domain,
+      'referrer'
+    )
+    if (allowedReferrer.total > 0) {
+      // scope test to this scan
+      if (this.event.test) {
+        lruKey = `${lruKey}|${this.event.scanID}`
+      }
+      domainAllowListCache.set(lruKey, 1)
+      return {
+        allowed: true,
+        message: `allow-listed / referer (${refererURL.domain}) (DB)`
+      }
+    }
+    return { allowed: false }
   }
 }
 

--- a/scanner/src/rules/unknown-domain.ts
+++ b/scanner/src/rules/unknown-domain.ts
@@ -100,6 +100,8 @@ export class UnknownDomainRule extends Rule {
       res.message = `${payloadURL.hostname} unknown`
     }
 
+    res.context.domain = payloadURL.hostname
+
     return this.resolveEvent(res)
   }
 }

--- a/scanner/src/rules/websocket.ts
+++ b/scanner/src/rules/websocket.ts
@@ -31,8 +31,9 @@ const iocDomainCache = new LRUCache({
 export class WebsocketRule extends Rule {
   alertResults: MerryMaker.RuleAlert[]
   async process(
-    payload: MerryMaker.WebFunctionCallEvent
+    scanEvent: MerryMaker.ScanEvent
   ): Promise<MerryMaker.RuleAlert[]> {
+    const payload = scanEvent.payload as MerryMaker.WebFunctionCallEvent
     this.alertResults = []
     const res: MerryMaker.RuleAlert = {
       name: this.options.name,

--- a/scanner/src/rules/yara.ts
+++ b/scanner/src/rules/yara.ts
@@ -37,8 +37,9 @@ const seenFilesCache = new LRUCache({
 export class YaraRule extends Rule {
   alertResults: MerryMaker.RuleAlert[]
   async process(
-    payload: MerryMaker.WebScriptEvent
+    scanEvent: MerryMaker.ScanEvent
   ): Promise<MerryMaker.RuleAlert[]> {
+    const payload = scanEvent.payload as MerryMaker.WebScriptEvent
     this.alertResults = []
     const res: MerryMaker.RuleAlert = {
       name: this.options.name,

--- a/scanner/src/tests/rules.unknown.domain.test.ts
+++ b/scanner/src/tests/rules.unknown.domain.test.ts
@@ -1,0 +1,286 @@
+import MerryMaker, { WebRequestEvent } from '@merrymaker/types'
+import Chance from 'chance'
+import nock from 'nock'
+import { config } from 'node-config-ts'
+
+import unknownDomainRule, {
+  domainAllowListCache,
+  seenDomainCache
+} from '../rules/unknown-domain'
+
+const chance = new Chance()
+
+describe('Unknown Domain Rule', () => {
+  afterEach(() => {
+    nock.cleanAll()
+  })
+  describe('unknown domain', () => {
+    let result: MerryMaker.RuleAlert[]
+    beforeAll(async () => {
+      domainAllowListCache.clear()
+      seenDomainCache.clear()
+      nock(config.transport.http)
+        .get('/api/allow_list/?key=testsite.test&type=fqdn&field=key')
+        .reply(200, { total: 0 })
+      nock(config.transport.http)
+        .post('/api/seen_strings/_cache', {
+          seen_string: {
+            key: 'www.testsite.test',
+            type: 'domain'
+          }
+        })
+        .reply(200, { store: 'none' })
+      result = await unknownDomainRule.process({
+        scanID: chance.guid(),
+        type: 'request',
+        payload: {
+          url: 'https://www.testsite.test'
+        } as WebRequestEvent
+      })
+    })
+    it('alerts on unknown domain', async () => {
+      expect(result[0].alert).toEqual(true)
+    })
+    it('updates seen_strings cache', () => {
+      const seen = seenDomainCache.get('www.testsite.test')
+      expect(seen).toEqual(1)
+    })
+  })
+
+  describe('known domain', () => {
+    beforeEach(() => {
+      domainAllowListCache.clear()
+      seenDomainCache.clear()
+    })
+
+    it('does not alert on known domain in remote seen_strings', async () => {
+      nock(config.transport.http)
+        .get('/api/allow_list/?key=testsite.test&type=fqdn&field=key')
+        .reply(200, { total: 0 })
+      nock(config.transport.http)
+        .post('/api/seen_strings/_cache', {
+          seen_string: {
+            key: 'www.testsite.test',
+            type: 'domain'
+          }
+        })
+        .reply(200, { store: 'database' })
+
+      const result = await unknownDomainRule.process({
+        scanID: chance.guid(),
+        type: 'request',
+        payload: {
+          url: 'https://www.testsite.test'
+        } as WebRequestEvent
+      })
+
+      expect(result[0].alert).toEqual(false)
+    })
+    it('does not alert on domain in remote allow list', async () => {
+      nock(config.transport.http)
+        .get('/api/allow_list/?key=testsite.test&type=fqdn&field=key')
+        .reply(200, { total: 1 })
+      const result = await unknownDomainRule.process({
+        scanID: chance.guid(),
+        type: 'request',
+        payload: {
+          url: 'https://www.testsite.test'
+        } as WebRequestEvent
+      })
+      expect(result[0].alert).toEqual(false)
+    })
+    it('does not alert on domain in local allow list cache', async () => {
+      domainAllowListCache.set('testsite.test', 1)
+      const result = await unknownDomainRule.process({
+        scanID: chance.guid(),
+        type: 'request',
+        payload: {
+          url: 'https://www.testsite.test'
+        } as WebRequestEvent
+      })
+      expect(result[0].alert).toEqual(false)
+    })
+    it('does not alert on domain in local seen_strings cache', async () => {
+      nock(config.transport.http)
+        .get('/api/allow_list/?key=testsite.test&type=fqdn&field=key')
+        .reply(200, { total: 0 })
+      seenDomainCache.set('www.testsite.test', 1)
+      const result = await unknownDomainRule.process({
+        scanID: chance.guid(),
+        type: 'request',
+        payload: {
+          url: 'https://www.testsite.test'
+        } as WebRequestEvent
+      })
+      expect(result[0].alert).toEqual(false)
+    })
+
+    describe('referrer', () => {
+      const event: WebRequestEvent = {
+        url: 'https://www.testsite.test',
+        method: 'GET',
+        resourceType: 'application/html',
+        postData: '',
+        response: {
+          headers: {},
+          status: 200,
+          url: 'https://www.testsite.test'
+        },
+        headers: {
+          referer: 'https://www.allowtest.test'
+        }
+      }
+      beforeEach(() => {
+        nock(config.transport.http)
+          .get('/api/allow_list/?key=testsite.test&type=fqdn&field=key')
+          .reply(200, { total: 0 })
+        nock(config.transport.http)
+          .post('/api/seen_strings/_cache', {
+            seen_string: {
+              key: 'www.testsite.test',
+              type: 'domain'
+            }
+          })
+          .reply(200, { store: 'none' })
+      })
+      it('does not alert on allowed referrer', async () => {
+        nock(config.transport.http)
+          .get('/api/allow_list/?key=allowtest.test&type=referrer&field=key')
+          .reply(200, { total: 1 })
+        const result = await unknownDomainRule.process({
+          scanID: chance.guid(),
+          type: 'request',
+          payload: event
+        })
+        expect(result[0].alert).toEqual(false)
+      })
+      it('updates cache', async () => {
+        nock(config.transport.http)
+          .get('/api/allow_list/?key=allowtest.test&type=referrer&field=key')
+          .reply(200, { total: 1 })
+        await unknownDomainRule.process({
+          scanID: chance.guid(),
+          type: 'request',
+          payload: event
+        })
+        expect(
+          domainAllowListCache.get('testsite.test|allowtest.test')
+        ).toEqual(1)
+      })
+      it('alerts on non allowed', async () => {
+        nock(config.transport.http)
+          .get('/api/allow_list/?key=allowtest.test&type=referrer&field=key')
+          .reply(200, { total: 0 })
+        const result = await unknownDomainRule.process({
+          scanID: chance.guid(),
+          type: 'request',
+          payload: event
+        })
+        expect(result[0].alert).toEqual(true)
+      })
+    })
+  })
+
+  describe('error handling', () => {
+    beforeEach(() => {
+      domainAllowListCache.clear()
+      seenDomainCache.clear()
+    })
+    it('handles invalid allow_list API response', async () => {
+      nock(config.transport.http)
+        .get('/api/allow_list/?key=testsite.test&type=fqdn&field=key')
+        .reply(200, { foo: 0 })
+      let err: Error
+      try {
+        await unknownDomainRule.process({
+          scanID: chance.guid(),
+          type: 'request',
+          payload: {
+            url: 'https://www.testsite.test'
+          } as WebRequestEvent
+        })
+      } catch (e) {
+        err = e
+      }
+      expect(err).not.toBeUndefined()
+    })
+    it('handles invalid seen strings API response ', async () => {
+      nock(config.transport.http)
+        .get('/api/allow_list/?key=testsite.test&type=fqdn&field=key')
+        .reply(200, { total: 0 })
+
+      nock(config.transport.http)
+        .post('/api/seen_strings/_cache', {
+          seen_string: {
+            key: 'www.testsite.test',
+            type: 'domain'
+          }
+        })
+        .reply(200, { foo: 'database' })
+
+      let err: Error
+
+      try {
+        await unknownDomainRule.process({
+          scanID: chance.guid(),
+          type: 'request',
+          payload: {
+            url: 'https://www.testsite.test'
+          } as WebRequestEvent
+        })
+      } catch (e) {
+        err = e
+      }
+      expect(err).not.toBeUndefined()
+    })
+  })
+  describe('test scans', () => {
+    let result: MerryMaker.RuleAlert[]
+    const scanID = chance.guid()
+
+    beforeAll(async () => {
+      domainAllowListCache.clear()
+      seenDomainCache.clear()
+      nock(config.transport.http)
+        .get('/api/allow_list/?key=testsite.test&type=fqdn&field=key')
+        .reply(200, { total: 0 })
+      nock(config.transport.http)
+        // note the GET instead of POST here
+        .get('/api/seen_strings/_cache')
+        .query({
+          key: 'www.testsite.test',
+          type: 'domain'
+        })
+        .reply(200, { store: 'none' })
+      result = await unknownDomainRule.process({
+        scanID,
+        test: true,
+        type: 'request',
+        payload: {
+          url: 'https://www.testsite.test'
+        } as WebRequestEvent
+      })
+    })
+    it('should alert', () => {
+      expect(result[0].alert).toEqual(true)
+    })
+    it('should scope seen_strings cache', () => {
+      expect(seenDomainCache.get(`www.testsite.test|${scanID}`)).toEqual(1)
+    })
+
+    it('should not alert on seen domain during test', async () => {
+      nock(config.transport.http)
+        .get('/api/allow_list/?key=testsite.test&type=fqdn&field=key')
+        .reply(200, { total: 0 })
+      const res2 = await unknownDomainRule.process({
+        scanID,
+        test: true,
+        type: 'request',
+        payload: {
+          url: 'https://www.testsite.test'
+        } as WebRequestEvent
+      })
+      expect(res2[0].alert).toEqual(false)
+    })
+  })
+})

--- a/yarn.lock
+++ b/yarn.lock
@@ -1302,6 +1302,13 @@
     "@jridgewell/resolve-uri" "^3.0.3"
     "@jridgewell/sourcemap-codec" "^1.4.10"
 
+"@merrymaker/types@^1.0.10":
+  version "1.0.10"
+  resolved "https://registry.yarnpkg.com/@merrymaker/types/-/types-1.0.10.tgz#4691e42a8bc836367a76e2efe3f47088c6acf30f"
+  integrity sha512-MFSmUP2SNQq5A9/yw85yyJyJYt9aBUwrtqOgrEXDDt/9XZJH4ufFv3wuro021bJhOCkBEI81s9V5mz7dwuNv7w==
+  dependencies:
+    "@types/puppeteer" "^5.4.4"
+
 "@merrymaker/types@^1.0.6":
   version "1.0.6"
   resolved "https://registry.yarnpkg.com/@merrymaker/types/-/types-1.0.6.tgz#8c2410decac82099b65c94b9692b6b747f7ae77a"
@@ -1763,6 +1770,13 @@
   resolved "https://registry.yarnpkg.com/@types/minimist/-/minimist-1.2.2.tgz#ee771e2ba4b3dc5b372935d549fd9617bf345b8c"
   integrity sha512-jhuKLIRrhvCPLqwPcx6INqmKeiA5EWrsCOPhrlFSrbrmU4ZMPjj5Ul/oLCMDO98XRUIwVm78xICz4EPCektzeQ==
 
+"@types/nock@^11.1.0":
+  version "11.1.0"
+  resolved "https://registry.yarnpkg.com/@types/nock/-/nock-11.1.0.tgz#0a8c1056a31ba32a959843abccf99626dd90a538"
+  integrity sha512-jI/ewavBQ7X5178262JQR0ewicPAcJhXS/iFaNJl0VHLfyosZ/kwSrsa6VNQNSO8i9d8SqdRgOtZSOKJ/+iNMw==
+  dependencies:
+    nock "*"
+
 "@types/node-fetch@^2.5.7":
   version "2.6.1"
   resolved "https://registry.yarnpkg.com/@types/node-fetch/-/node-fetch-2.6.1.tgz#8f127c50481db65886800ef496f20bbf15518975"
@@ -1839,6 +1853,13 @@
   version "3.0.7"
   resolved "https://registry.yarnpkg.com/@types/puppeteer/-/puppeteer-3.0.7.tgz#43e5baa3a2d515d895d5a01b50b2b523ff76b966"
   integrity sha512-fwmQHrM+CbJd/ZUD4IBXmEKMF3nPMLQL+CaTSfzjo/ayElg8AIzFLcJZ81nCFR47RxLJRdAuSydtlky7N1cwkw==
+  dependencies:
+    "@types/node" "*"
+
+"@types/puppeteer@^5.4.4":
+  version "5.4.5"
+  resolved "https://registry.yarnpkg.com/@types/puppeteer/-/puppeteer-5.4.5.tgz#154e3850a77bfd3967f036680de8ddc88eb3a12b"
+  integrity sha512-lxCjpDEY+DZ66+W3x5Af4oHnEmUXt0HuaRzkBGE2UZiZEp/V1d3StpLPlmNVu/ea091bdNmVPl44lu8Wy/0ZCA==
   dependencies:
     "@types/node" "*"
 
@@ -5184,7 +5205,7 @@ express-session@^1.17.1:
     safe-buffer "5.2.1"
     uid-safe "~2.1.5"
 
-express@^4.17.1:
+express@^4.17.1, express@^4.17.3:
   version "4.17.3"
   resolved "https://registry.yarnpkg.com/express/-/express-4.17.3.tgz#f6c7302194a4fb54271b73a1fe7a06478c8f85a1"
   integrity sha512-yuSQpz5I+Ch7gFrPCk4/c+dIBKlQUxtgwqzph132bsT6qhuzss6I8cLJQz7B3rFblzd6wtcI0ZbGltH/C4LjUg==
@@ -7210,7 +7231,7 @@ json-stringify-pretty-compact@^3.0.0, json-stringify-pretty-compact@~3.0.0:
   resolved "https://registry.yarnpkg.com/json-stringify-pretty-compact/-/json-stringify-pretty-compact-3.0.0.tgz#f71ef9d82ef16483a407869556588e91b681d9ab"
   integrity sha512-Rc2suX5meI0S3bfdZuA7JMFBGkJ875ApfVyq2WHELjBiiG22My/l7/8zPpH/CfFVQHuVLd8NLR0nv6vi0BYYKA==
 
-json-stringify-safe@~5.0.1:
+json-stringify-safe@^5.0.1, json-stringify-safe@~5.0.1:
   version "5.0.1"
   resolved "https://registry.yarnpkg.com/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz#1296a2d58fd45f19a0f6ce01d65701e2c735b6eb"
   integrity sha1-Epai1Y/UXxmg9s4B1lcB4sc1tus=
@@ -7501,6 +7522,11 @@ lodash.once@^4.1.1:
   version "4.1.1"
   resolved "https://registry.yarnpkg.com/lodash.once/-/lodash.once-4.1.1.tgz#0dd3971213c7c56df880977d504c88fb471a97ac"
   integrity sha1-DdOXEhPHxW34gJd9UEyI+0cal6w=
+
+lodash.set@^4.3.2:
+  version "4.3.2"
+  resolved "https://registry.yarnpkg.com/lodash.set/-/lodash.set-4.3.2.tgz#d8757b1da807dde24816b0d6a84bea1a76230b23"
+  integrity sha1-2HV7HagH3eJIFrDWqEvqGnYjCyM=
 
 lodash.truncate@^4.4.2:
   version "4.4.2"
@@ -7925,6 +7951,16 @@ nocache@2.1.0:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/nocache/-/nocache-2.1.0.tgz#120c9ffec43b5729b1d5de88cd71aa75a0ba491f"
   integrity sha512-0L9FvHG3nfnnmaEQPjT9xhfN4ISk0A8/2j4M37Np4mcDesJjHgEUfgPhdCyZuFI954tjokaIj/A3NdpFNdEh4Q==
+
+nock@*, nock@^13.2.4:
+  version "13.2.4"
+  resolved "https://registry.yarnpkg.com/nock/-/nock-13.2.4.tgz#43a309d93143ee5cdcca91358614e7bde56d20e1"
+  integrity sha512-8GPznwxcPNCH/h8B+XZcKjYPXnUV5clOKCjAqyjsiqA++MpNx9E9+t8YPp0MbThO+KauRo7aZJ1WuIZmOrT2Ug==
+  dependencies:
+    debug "^4.1.0"
+    json-stringify-safe "^5.0.1"
+    lodash.set "^4.3.2"
+    propagate "^2.0.0"
 
 node-config-ts@^3.0.4:
   version "3.1.0"
@@ -8995,6 +9031,11 @@ prompts@^2.0.1:
   dependencies:
     kleur "^3.0.3"
     sisteransi "^1.0.5"
+
+propagate@^2.0.0:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/propagate/-/propagate-2.0.1.tgz#40cdedab18085c792334e64f0ac17256d38f9a45"
+  integrity sha512-vGrhOavPSTz4QVNuBNdcNXePNdNMaO1xj9yBeH1ScQPjk/rhg9sSlCXPhMkFuaNNW/syTvYqsnbIJxMBfRbbag==
 
 proto-list@~1.2.1:
   version "1.2.4"


### PR DESCRIPTION
Include additional context in alert message for easier enrichments (planned).

- Updates unknown.domain rule to include `{ context: { domain: <hostname> } }` in the alert