### PR TITLE
improvement(alerts): test scoping and unactionable alerts

### DIFF
--- a/scanner/src/tests/rules.unknown.domain.test.ts
+++ b/scanner/src/tests/rules.unknown.domain.test.ts
@@ -267,5 +267,20 @@ describe('Unknown Domain Rule', () => {
     it('should scope seen_strings cache', () => {
       expect(seenDomainCache.get(`www.testsite.test|${scanID}`)).toEqual(1)
     })
+
+    it('should not alert on seen domain during test', async () => {
+      nock(config.transport.http)
+        .get('/api/allow_list/?key=testsite.test&type=fqdn&field=key')
+        .reply(200, { total: 0 })
+      const res2 = await unknownDomainRule.process({
+        scanID,
+        test: true,
+        type: 'request',
+        payload: {
+          url: 'https://www.testsite.test'
+        } as WebRequestEvent
+      })
+      expect(res2[0].alert).toEqual(false)
+    })
   })
 })

--- a/scanner/src/worker.ts
+++ b/scanner/src/worker.ts
@@ -2,7 +2,7 @@ import {
   EventResult,
   RuleAlert,
   RuleAlertEvent,
-  GeneralErrorEvent,
+  GeneralErrorEvent
 } from '@merrymaker/types'
 import Bull, { Job } from 'bull'
 import BullWorker from './lib/bull-worker'
@@ -13,11 +13,11 @@ import { RuleJobData } from './lib/scan-event-handler'
 import logger from './loaders/logger'
 
 const jsScopeEventQueue = new Bull<EventResult>('browser-event-queue', {
-  createClient: resolveClient,
+  createClient: resolveClient
 })
 
 const scanLogEventQueue = new Bull<EventResult>('scan-log-queue', {
-  createClient: resolveClient,
+  createClient: resolveClient
 })
 const ruleQueue = new Bull('rule-queue', { createClient: resolveClient })
 ;(async () => {
@@ -36,18 +36,18 @@ jsScopeEventQueue.process(async (job: Job) => {
         entry: job.data.type,
         test: job.data.test,
         level: 'info',
-        event: job.data.payload,
+        event: job.data.payload
       },
       {
         removeOnComplete: true,
-        removeOnFail: 25,
+        removeOnFail: 25
       }
     )
     await scanHandler.scheduleRules(job.data, ruleQueue)
   }
 })
 
-ruleQueue.on('error', (e) => {
+ruleQueue.on('error', e => {
   logger.error({ queue: 'rule', error: e.message })
 })
 
@@ -68,20 +68,35 @@ const ruleQueueManager = new BullWorker(
       const events = await scanHandler.process(job.data)
       if (events) {
         await scanLogEventQueue.addBulk(
-          events.map((evt: RuleAlert) => {
-            return {
-              data: {
-                entry: 'rule-alert',
-                level: 'info',
-                rule: evt.name,
-                scan_id: job.data.event.scanID,
-                event: evt,
-              } as RuleAlertEvent,
-              opts: {
-                removeOnComplete: true,
-              },
-            }
-          })
+          events
+            .filter((evt: RuleAlert) => {
+              if (evt.alert === false) {
+                logger.info({
+                  queue: 'rule',
+                  scan_id: job.data.event.scanID,
+                  rule: evt.name,
+                  event: evt,
+                  message: 'dropping false alert'
+                })
+                return false
+              }
+              return true
+            })
+            .map((evt: RuleAlert) => {
+              return {
+                data: {
+                  entry: 'rule-alert',
+                  level: 'info',
+                  rule: evt.name,
+                  scan_id: job.data.event.scanID,
+                  test: job.data.event.test,
+                  event: evt
+                } as RuleAlertEvent,
+                opts: {
+                  removeOnComplete: true
+                }
+              }
+            })
         )
       } else {
         logger.info({ queue: 'rule', status: 'no rule alerts' })
@@ -94,8 +109,8 @@ const ruleQueueManager = new BullWorker(
           level: 'error',
           scan_id: job.data.event.scanID,
           event: {
-            message: e.message,
-          },
+            message: e.message
+          }
         } as GeneralErrorEvent,
         { removeOnComplete: true }
       )
@@ -103,10 +118,10 @@ const ruleQueueManager = new BullWorker(
   }
 )
 
-ruleQueueManager.on('info', (msg) => {
+ruleQueueManager.on('info', msg => {
   logger.info(`rules queue manager info - ${msg}`, msg)
 })
-ruleQueueManager.on('error', (err) => {
+ruleQueueManager.on('error', err => {
   logger.error(`rules queue manager error (${err.message})`)
 })
 // eslint-disable-next-line @typescript-eslint/explicit-function-return-type


### PR DESCRIPTION
Stacked PR on #57 

Stop sending alerts if the outcome was `false`.
Scope allow-list/seenString on test scan IDs to prevent real scan collisions.