### PR TITLE
feat(job): notify on job failure only when retries are exhausted

### DIFF
--- a/services/merrymaker-go/frontend/biome.json
+++ b/services/merrymaker-go/frontend/biome.json
@@ -1,5 +1,5 @@
 {
-	"$schema": "https://biomejs.dev/schemas/2.2.5/schema.json",
+	"$schema": "https://biomejs.dev/schemas/2.3.10/schema.json",
 	"vcs": {
 		"enabled": true,
 		"clientKind": "git",

--- a/services/merrymaker-go/frontend/public/js/components/modal.js
+++ b/services/merrymaker-go/frontend/public/js/components/modal.js
@@ -38,8 +38,8 @@
  */
 
 import { h, qs } from "../core/dom.js";
-import { Lifecycle } from "../core/lifecycle.js";
 import { Events } from "../core/events.js";
+import { Lifecycle } from "../core/lifecycle.js";
 
 /**
  * Modal class for creating and managing modal dialogs

--- a/services/merrymaker-go/frontend/public/js/components/modal.test.js
+++ b/services/merrymaker-go/frontend/public/js/components/modal.test.js
@@ -2,7 +2,7 @@
  * Tests for Modal Component
  */
 
-import { describe, it, expect, beforeEach, afterEach } from "bun:test";
+import { afterEach, beforeEach, describe, expect, it } from "bun:test";
 import { Modal } from "./modal.js";
 
 describe("Modal Component", () => {

--- a/services/merrymaker-go/frontend/public/js/components/poller.test.js
+++ b/services/merrymaker-go/frontend/public/js/components/poller.test.js
@@ -1,4 +1,4 @@
-import { describe, it, expect, beforeEach, afterEach, mock } from "bun:test";
+import { afterEach, beforeEach, describe, expect, it, mock } from "bun:test";
 import { Poller } from "./poller.js";
 
 describe("Poller", () => {

--- a/services/merrymaker-go/frontend/public/js/components/toast.test.js
+++ b/services/merrymaker-go/frontend/public/js/components/toast.test.js
@@ -2,8 +2,8 @@
  * Tests for Toast Component
  */
 
-import { describe, it, expect, beforeEach, afterEach } from "bun:test";
-import { showToast, removeToast } from "./toast.js";
+import { afterEach, beforeEach, describe, expect, it } from "bun:test";
+import { removeToast, showToast } from "./toast.js";
 
 describe("Toast Component", () => {
 	let container;

--- a/services/merrymaker-go/frontend/public/js/core/dom.test.js
+++ b/services/merrymaker-go/frontend/public/js/core/dom.test.js
@@ -1,5 +1,5 @@
-import { describe, it, expect, beforeEach } from "bun:test";
-import { h, qs, qsa, htmlToFragment, htmlToElement, clearElement } from "./dom.js";
+import { beforeEach, describe, expect, it } from "bun:test";
+import { clearElement, h, htmlToElement, htmlToFragment, qs, qsa } from "./dom.js";
 
 describe("DOM Utilities", () => {
 	describe("h() - Element Creation", () => {

--- a/services/merrymaker-go/frontend/public/js/core/state.test.js
+++ b/services/merrymaker-go/frontend/public/js/core/state.test.js
@@ -1,4 +1,4 @@
-import { describe, it, expect, beforeEach } from "bun:test";
+import { beforeEach, describe, expect, it } from "bun:test";
 import { State } from "./state.js";
 
 describe("State Management", () => {

--- a/services/merrymaker-go/frontend/public/js/features/row-nav.test.js
+++ b/services/merrymaker-go/frontend/public/js/features/row-nav.test.js
@@ -1,4 +1,4 @@
-import { describe, it, expect, beforeEach, afterEach } from "bun:test";
+import { afterEach, beforeEach, describe, expect, it } from "bun:test";
 import { initRowNav } from "./row-nav.js";
 
 describe("row-nav feature", () => {

--- a/services/merrymaker-go/frontend/public/js/features/screenshot.js
+++ b/services/merrymaker-go/frontend/public/js/features/screenshot.js
@@ -4,8 +4,9 @@
  * Wires up thumbnail triggers and exposes the modal helper globally for areas
  * that still access it via `window.showScreenshotModal`.
  */
-import { Events } from "../core/events.js";
+
 import { showScreenshotModal } from "../components/screenshot-modal.js";
+import { Events } from "../core/events.js";
 
 let initialized = false;
 let observer;


### PR DESCRIPTION
- Refactor `FailWithDetails` to defer job failure notifications until all retries are exhausted, except when `MaxRetries` is zero.
- Add `shouldNotifyFailure` and `inferFailureStatus` helpers for clearer notification logic.
- Update job failure payload metadata to reflect correct retry count and status.
- Add test to ensure notification is skipped until retries are exhausted.
- Minor import and ordering cleanups in frontend JS for consistency.