### PR TITLE
feat(ci): add reusable Docker build workflow and service-specific pip…

### DIFF
--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -1,0 +1,95 @@
+name: Docker Build (Reusable)
+
+on:
+  workflow_call:
+    inputs:
+      image:
+        description: Fully qualified image name, e.g. ghcr.io/org/repo/service
+        required: true
+        type: string
+      tag_prefix:
+        description: Optional tag prefix (useful when multiple services share one repo)
+        required: false
+        type: string
+        default: ""
+      context:
+        description: Docker build context path (repo-relative)
+        required: true
+        type: string
+      dockerfile:
+        description: Dockerfile path (repo-relative)
+        required: true
+        type: string
+      push:
+        description: Whether to push the built image(s) to the registry
+        required: true
+        type: boolean
+      pre_build_workdir:
+        description: Optional working directory for pre-build step
+        required: false
+        type: string
+        default: ""
+      pre_build_cmd:
+        description: Optional shell command(s) to run before docker build
+        required: false
+        type: string
+        default: ""
+
+permissions:
+  contents: read
+
+jobs:
+  build:
+    name: Build${{ inputs.push && ' & Push' || '' }}
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Bun
+        if: ${{ inputs.pre_build_cmd != '' }}
+        uses: oven-sh/setup-bun@v1
+        with:
+          bun-version: "1.2.2"
+
+      - name: Pre-build
+        if: ${{ inputs.pre_build_cmd != '' }}
+        working-directory: ${{ inputs.pre_build_workdir }}
+        shell: bash
+        run: ${{ inputs.pre_build_cmd }}
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Log in to Docker Hub
+        if: ${{ inputs.push }}
+        uses: docker/login-action@v3
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+
+      - name: Docker metadata
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ${{ inputs.image }}
+          tags: |
+            type=semver,pattern={{version}},prefix=${{ inputs.tag_prefix }}
+            type=sha,prefix=${{ inputs.tag_prefix }}
+
+      - name: Build${{ inputs.push && ' & push' || '' }}
+        uses: docker/build-push-action@v6
+        with:
+          context: ${{ inputs.context }}
+          file: ${{ inputs.dockerfile }}
+          platforms: linux/amd64
+          push: ${{ inputs.push }}
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          build-args: |
+            VERSION=${{ steps.meta.outputs.version || github.sha }}
+            VCS_REF=${{ github.sha }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+          provenance: true
+          sbom: true

--- a/.github/workflows/docker-merrymaker-go.yml
+++ b/.github/workflows/docker-merrymaker-go.yml
@@ -1,0 +1,32 @@
+name: Docker Image - merrymaker-go
+
+on:
+  pull_request:
+    paths:
+      - "services/merrymaker-go/**"
+      - ".github/workflows/docker-*.yml"
+  push:
+    tags:
+      - "v*.*.*"
+
+permissions:
+  contents: read
+  packages: write
+
+concurrency:
+  group: docker-merrymaker-go-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  docker:
+    uses: ./.github/workflows/docker-build.yml
+    with:
+      image: target/merrymaker
+      tag_prefix: merrymaker-go-
+      context: services/merrymaker-go
+      dockerfile: services/merrymaker-go/Dockerfile
+      push: ${{ github.event_name == 'push' }}
+      pre_build_workdir: services/merrymaker-go/frontend
+      pre_build_cmd: |
+        bun install --frozen-lockfile
+        bun run build

--- a/.github/workflows/docker-puppeteer-worker.yml
+++ b/.github/workflows/docker-puppeteer-worker.yml
@@ -1,0 +1,28 @@
+name: Docker Image - puppeteer-worker
+
+on:
+  pull_request:
+    paths:
+      - "services/puppeteer-worker/**"
+      - ".github/workflows/docker-*.yml"
+  push:
+    tags:
+      - "v*.*.*"
+
+permissions:
+  contents: read
+  packages: write
+
+concurrency:
+  group: docker-puppeteer-worker-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  docker:
+    uses: ./.github/workflows/docker-build.yml
+    with:
+      image: target/merrymaker
+      tag_prefix: puppeteer-worker-
+      context: services/puppeteer-worker
+      dockerfile: services/puppeteer-worker/Dockerfile
+      push: ${{ github.event_name == 'push' }}

--- a/services/merrymaker-go/.dockerignore
+++ b/services/merrymaker-go/.dockerignore
@@ -9,8 +9,8 @@
 
 # Binaries / local build outputs
 bin
-merrymaker
-merrymaker-prod
+/merrymaker
+/merrymaker-prod
 
 # Frontend dev-only deps
 frontend/node_modules


### PR DESCRIPTION
…elines

- Add `.github/workflows/docker-build.yml` as a reusable workflow for building and optionally pushing Docker images, supporting pre-build steps and flexible configuration.
- Add `.github/workflows/docker-merrymaker-go.yml` and `.github/workflows/docker-puppeteer-worker.yml` to build and publish images for `merrymaker-go` and `puppeteer-worker` services, using the reusable workflow.
- Enable image builds on PRs and tag pushes, with concurrency control and pre-build frontend steps for `merrymaker-go`.