### PR TITLE
fix(auth): validate OAuth state in Exchange to prevent CSRF

### DIFF
--- a/services/merrymaker-go/internal/adapters/devauth/provider.go
+++ b/services/merrymaker-go/internal/adapters/devauth/provider.go
@@ -70,8 +70,17 @@ func (p *Provider) Begin(_ context.Context, _ ports.BeginInput) (string, string,
 	return authURL, state, nonce, nil
 }
 
-// Exchange ignores the provided code/state/nonce (validation handled by handler) and returns the dev identity.
-func (p *Provider) Exchange(_ context.Context, _ ports.ExchangeInput) (domainauth.Identity, error) {
+// Exchange validates state and returns the dev identity.
+func (p *Provider) Exchange(_ context.Context, in ports.ExchangeInput) (domainauth.Identity, error) {
+	if in.State == "" {
+		return domainauth.Identity{}, errors.New("state is required")
+	}
+	if in.ExpectedState == "" {
+		return domainauth.Identity{}, errors.New("expected state is required")
+	}
+	if in.State != in.ExpectedState {
+		return domainauth.Identity{}, errors.New("state mismatch: possible CSRF attack")
+	}
 	// Refresh expiry on each exchange for convenience
 	if time.Until(p.identity.ExpiresAt) < 5*time.Minute {
 		p.identity.ExpiresAt = time.Now().Add(p.sessionDuration)

--- a/services/merrymaker-go/internal/adapters/devauth/provider_test.go
+++ b/services/merrymaker-go/internal/adapters/devauth/provider_test.go
@@ -23,7 +23,7 @@ func TestProvider_BeginAndExchange(t *testing.T) {
 	if state == "" || nonce == "" {
 		t.Fatal("state and nonce should be generated")
 	}
-	id, err := prov.Exchange(context.Background(), ports.ExchangeInput{Code: "dev", State: state, Nonce: nonce})
+	id, err := prov.Exchange(context.Background(), ports.ExchangeInput{Code: "dev", State: state, ExpectedState: state, Nonce: nonce})
 	if err != nil {
 		t.Fatalf("Exchange error: %v", err)
 	}

--- a/services/merrymaker-go/internal/adapters/oidc/provider.go
+++ b/services/merrymaker-go/internal/adapters/oidc/provider.go
@@ -133,6 +133,12 @@ func (p *Provider) Exchange(ctx context.Context, in ports.ExchangeInput) (domain
 	if in.State == "" {
 		return domainauth.Identity{}, errors.New("state is required")
 	}
+	if in.ExpectedState == "" {
+		return domainauth.Identity{}, errors.New("expected state is required")
+	}
+	if in.State != in.ExpectedState {
+		return domainauth.Identity{}, errors.New("state mismatch: possible CSRF attack")
+	}
 	if in.Nonce == "" {
 		return domainauth.Identity{}, errors.New("nonce is required")
 	}

--- a/services/merrymaker-go/internal/adapters/oidc/provider_test.go
+++ b/services/merrymaker-go/internal/adapters/oidc/provider_test.go
@@ -134,17 +134,27 @@ func TestProvider_Exchange_ValidationErrors(t *testing.T) {
 	}{
 		{
 			name:   "missing code",
-			input:  ports.ExchangeInput{State: "state", Nonce: "nonce"},
+			input:  ports.ExchangeInput{State: "state", ExpectedState: "state", Nonce: "nonce"},
 			errMsg: "authorization code is required",
 		},
 		{
 			name:   "missing state",
-			input:  ports.ExchangeInput{Code: "code", Nonce: "nonce"},
+			input:  ports.ExchangeInput{Code: "code", ExpectedState: "state", Nonce: "nonce"},
 			errMsg: "state is required",
 		},
 		{
+			name:   "missing expected state",
+			input:  ports.ExchangeInput{Code: "code", State: "state", Nonce: "nonce"},
+			errMsg: "expected state is required",
+		},
+		{
+			name:   "state mismatch",
+			input:  ports.ExchangeInput{Code: "code", State: "state", ExpectedState: "other", Nonce: "nonce"},
+			errMsg: "state mismatch",
+		},
+		{
 			name:   "missing nonce",
-			input:  ports.ExchangeInput{Code: "code", State: "state"},
+			input:  ports.ExchangeInput{Code: "code", State: "state", ExpectedState: "state"},
 			errMsg: "nonce is required",
 		},
 	}
@@ -224,9 +234,10 @@ func TestProvider_Exchange_MockSuccess(t *testing.T) {
 	ctx := context.Background()
 
 	input := ports.ExchangeInput{
-		Code:  "test-code",
-		State: "test-state",
-		Nonce: "test-nonce",
+		Code:          "test-code",
+		State:         "test-state",
+		ExpectedState: "test-state",
+		Nonce:         "test-nonce",
 	}
 
 	// This will fail because we don't have a real token endpoint,

--- a/services/merrymaker-go/internal/http/handlers_auth.go
+++ b/services/merrymaker-go/internal/http/handlers_auth.go
@@ -113,9 +113,10 @@ func (h *AuthHandlers) Callback(w http.ResponseWriter, r *http.Request) {
 
 	// Complete the login flow
 	result, err := h.Svc.CompleteLogin(r.Context(), service.CompleteLoginInput{
-		Code:  code,
-		State: state,
-		Nonce: nonceCookie.Value,
+		Code:          code,
+		State:         state,
+		ExpectedState: stateCookie.Value,
+		Nonce:         nonceCookie.Value,
 	})
 	if err != nil {
 		WriteError(w, ErrorParams{

--- a/services/merrymaker-go/internal/mocks/auth/auth_test.go
+++ b/services/merrymaker-go/internal/mocks/auth/auth_test.go
@@ -70,9 +70,10 @@ func TestMockAuthProvider_Exchange_Defaults(t *testing.T) {
 	ctx := context.Background()
 
 	input := ports.ExchangeInput{
-		Code:  "auth-code",
-		State: "state-1",
-		Nonce: "nonce-1",
+		Code:          "auth-code",
+		State:         "state-1",
+		ExpectedState: "state-1",
+		Nonce:         "nonce-1",
 	}
 	identity, err := provider.Exchange(ctx, input)
 
@@ -97,9 +98,10 @@ func TestMockAuthProvider_Exchange_CustomUser(t *testing.T) {
 	ctx := context.Background()
 
 	input := ports.ExchangeInput{
-		Code:  "auth-code",
-		State: "state-1",
-		Nonce: "nonce-1",
+		Code:          "auth-code",
+		State:         "state-1",
+		ExpectedState: "state-1",
+		Nonce:         "nonce-1",
 	}
 	identity, err := provider.Exchange(ctx, input)
 
@@ -124,9 +126,10 @@ func TestMockAuthProvider_Exchange_CustomFunc(t *testing.T) {
 	ctx := context.Background()
 
 	input := ports.ExchangeInput{
-		Code:  "auth-code",
-		State: "state-1",
-		Nonce: "nonce-1",
+		Code:          "auth-code",
+		State:         "state-1",
+		ExpectedState: "state-1",
+		Nonce:         "nonce-1",
 	}
 	identity, err := provider.Exchange(ctx, input)
 

--- a/services/merrymaker-go/internal/ports/auth.go
+++ b/services/merrymaker-go/internal/ports/auth.go
@@ -25,9 +25,10 @@ type AuthProvider interface {
 
 // ExchangeInput groups parameters for the code/token exchange.
 type ExchangeInput struct {
-	Code  string
-	State string
-	Nonce string
+	Code          string
+	State         string // State returned by the IdP in the callback
+	ExpectedState string // Expected state value (from Begin) for CSRF validation
+	Nonce         string
 }
 
 // SessionStore persists and retrieves user sessions.

--- a/services/merrymaker-go/internal/service/auth.go
+++ b/services/merrymaker-go/internal/service/auth.go
@@ -64,9 +64,10 @@ func (s *AuthService) BeginLogin(ctx context.Context, redirectURL string) (*Begi
 
 // CompleteLoginInput groups parameters for completing a login flow.
 type CompleteLoginInput struct {
-	Code  string
-	State string
-	Nonce string
+	Code          string
+	State         string
+	ExpectedState string // Expected state value from Begin (for CSRF validation)
+	Nonce         string
 }
 
 // CompleteLoginResult contains the result of completing a login flow.
@@ -89,9 +90,10 @@ func (s *AuthService) CompleteLogin(ctx context.Context, input CompleteLoginInpu
 
 	// Exchange authorization code for identity
 	exchangeInput := ports.ExchangeInput{
-		Code:  input.Code,
-		State: input.State,
-		Nonce: input.Nonce,
+		Code:          input.Code,
+		State:         input.State,
+		ExpectedState: input.ExpectedState,
+		Nonce:         input.Nonce,
 	}
 	identity, err := s.provider.Exchange(ctx, exchangeInput)
 	if err != nil {

--- a/services/merrymaker-go/internal/service/auth_test.go
+++ b/services/merrymaker-go/internal/service/auth_test.go
@@ -142,9 +142,10 @@ func TestAuthService_CompleteLogin_Success(t *testing.T) {
 
 	ctx := context.Background()
 	input := CompleteLoginInput{
-		Code:  "auth-code",
-		State: "state-1",
-		Nonce: "nonce-1",
+		Code:          "auth-code",
+		State:         "state-1",
+		ExpectedState: "state-1",
+		Nonce:         "nonce-1",
 	}
 
 	result, err := service.CompleteLogin(ctx, input)
@@ -172,7 +173,7 @@ func TestAuthService_CompleteLogin_PopulatesNames(t *testing.T) {
 
 	service := NewAuthService(AuthServiceOptions{Provider: provider, Sessions: sessions, Roles: roles})
 	ctx := context.Background()
-	input := CompleteLoginInput{Code: "code", State: "state", Nonce: "nonce"}
+	input := CompleteLoginInput{Code: "code", State: "state", ExpectedState: "state", Nonce: "nonce"}
 	result, err := service.CompleteLogin(ctx, input)
 	require.NoError(t, err)
 	assert.Equal(t, "Mock", result.Session.FirstName)
@@ -201,9 +202,10 @@ func TestAuthService_CompleteLogin_AdminRole(t *testing.T) {
 
 	ctx := context.Background()
 	input := CompleteLoginInput{
-		Code:  "auth-code",
-		State: "state-1",
-		Nonce: "nonce-1",
+		Code:          "auth-code",
+		State:         "state-1",
+		ExpectedState: "state-1",
+		Nonce:         "nonce-1",
 	}
 
 	result, err := service.CompleteLogin(ctx, input)


### PR DESCRIPTION
CodeQL flagged go/constant-oauth2-state because Provider.Exchange accepted the state parameter without validating it against the expected value generated during Begin().

While the HTTP handler already validates state via cookies, the provider layer had no defense-in-depth validation, violating the AuthProvider contract that states Exchange should verify state.

Changes:
- Add ExpectedState field to ExchangeInput (ports/auth.go)
- Wire expected state through CompleteLoginInput (service/auth.go)
- Pass cookie state as ExpectedState in Callback handler (http/handlers_auth.go)
- Add state == expectedState validation in OIDC and devauth Exchange
- Update all tests with ExpectedState values
- Add state mismatch test case to OIDC provider tests