### PR TITLE
refactor(templates): extract shared render logic into tmplutil package

### DIFF
--- a/services/merrymaker-go/internal/data/export_contract_test.go
+++ b/services/merrymaker-go/internal/data/export_contract_test.go
@@ -44,7 +44,6 @@ func TestJobRepoExportedMethodsMatchAllowlist(t *testing.T) {
 	seen := make(map[string]struct{})
 
 	for m := range methods.Methods() {
-		m := m
 		if !m.IsExported() {
 			continue
 		}

--- a/services/merrymaker-go/internal/data/job_repo_test.go
+++ b/services/merrymaker-go/internal/data/job_repo_test.go
@@ -998,8 +998,12 @@ func TestJobRepo_Delete(t *testing.T) {
 }
 
 // Helper functions.
-func jobTypePtr(v model.JobType) *model.JobType   { return &v }
-func jobStatusPtr(v model.JobStatus) *model.JobStatus { return &v }
+//
+//go:fix inline
+func jobTypePtr(v model.JobType) *model.JobType { return new(v) }
+
+//go:fix inline
+func jobStatusPtr(v model.JobStatus) *model.JobStatus { return new(v) }
 
 func TestJobRepo_ListRecentByTypeWithSiteNames(t *testing.T) {
 	testutil.SkipIfNoTestDB(t)

--- a/services/merrymaker-go/internal/http/templates/core/funcs.go
+++ b/services/merrymaker-go/internal/http/templates/core/funcs.go
@@ -1,15 +1,14 @@
 package core
 
 import (
-	"bytes"
 	"encoding/json"
-	"errors"
 	"fmt"
 	"html/template"
 	"strconv"
 	"strings"
 	"time"
 
+	"github.com/target/mmk-ui-api/internal/http/templates/tmplutil"
 	"github.com/target/mmk-ui-api/internal/http/uiutil"
 )
 
@@ -40,18 +39,9 @@ func Funcs(deps Deps) template.FuncMap {
 }
 
 func addRenderFuncs(funcs template.FuncMap, deps Deps) {
+	render := tmplutil.RenderPartial(deps.Template)
 	funcs["renderSection"] = func(page string, data any) (template.HTML, error) {
-		if deps.Template == nil || *deps.Template == nil {
-			return "", errors.New("template not initialized")
-		}
-		var buf bytes.Buffer
-		if err := (*deps.Template).ExecuteTemplate(&buf, deps.ContentTemplateFor(page), data); err != nil {
-			return "", err
-		}
-		// #nosec G203 - The HTML here is rendered by our own trusted templates (html/template),
-		// and is embedded back into the same template set. User-provided values were already
-		// auto-escaped during ExecuteTemplate above.
-		return template.HTML(buf.String()), nil
+		return render(deps.ContentTemplateFor(page), data)
 	}
 
 	funcs["toJSON"] = func(v any) (string, error) {

--- a/services/merrymaker-go/internal/http/templates/events/funcs.go
+++ b/services/merrymaker-go/internal/http/templates/events/funcs.go
@@ -1,15 +1,14 @@
 package events
 
 import (
-	"bytes"
 	"encoding/json"
-	"errors"
 	"fmt"
 	"html/template"
 	"strconv"
 	"strings"
 
 	"github.com/target/mmk-ui-api/internal/domain/model"
+	"github.com/target/mmk-ui-api/internal/http/templates/tmplutil"
 )
 
 // Deps contains the dependencies required to build event-related template helpers.
@@ -35,17 +34,7 @@ func Funcs(deps Deps) template.FuncMap {
 		"isHTTPURL":                IsHTTPURL,
 	}
 
-	funcs["renderEventPartial"] = func(name string, data any) (template.HTML, error) {
-		if deps.Template == nil || *deps.Template == nil {
-			return "", errors.New("template not initialized")
-		}
-		var buf bytes.Buffer
-		if err := (*deps.Template).ExecuteTemplate(&buf, name, data); err != nil {
-			return "", err
-		}
-		// #nosec G203 - Rendered HTML originates from our trusted template set and varies only by data already escaped by html/template.
-		return template.HTML(buf.String()), nil
-	}
+	funcs["renderEventPartial"] = tmplutil.RenderPartial(deps.Template)
 
 	return funcs
 }

--- a/services/merrymaker-go/internal/http/templates/tmplutil/render.go
+++ b/services/merrymaker-go/internal/http/templates/tmplutil/render.go
@@ -1,0 +1,30 @@
+// Package tmplutil provides template helper utilities shared across template sub-packages.
+package tmplutil
+
+import (
+	"bytes"
+	"errors"
+	"html/template"
+)
+
+// RenderPartial returns a template.FuncMap-compatible closure that executes a named
+// sub-template into a buffer and returns the result as trusted template.HTML.
+//
+// The caller is responsible for ensuring that t always refers to the authoritative
+// *template.Template pointer so late-bound template sets (registered after Funcs is
+// called) are picked up correctly.
+func RenderPartial(t **template.Template) func(string, any) (template.HTML, error) {
+	return func(name string, data any) (template.HTML, error) {
+		if t == nil || *t == nil {
+			return "", errors.New("template not initialized")
+		}
+		var buf bytes.Buffer
+		if err := (*t).ExecuteTemplate(&buf, name, data); err != nil {
+			return "", err
+		}
+		// #nosec G203 - The HTML here is rendered by our own trusted templates (html/template)
+		// and is embedded back into the same template set. User-provided values were already
+		// auto-escaped during ExecuteTemplate above.
+		return template.HTML(buf.String()), nil //nolint:gosec // G203: see comment above
+	}
+}


### PR DESCRIPTION
Centralize the repeated pattern of executing sub-templates and wrapping results in `template.HTML` to reduce code duplication and improve maintainability.

- Create new `tmplutil.RenderPartial` helper function
- Replace inline buffer execution in core template funcs
- Replace inline buffer execution in events template funcs
- Remove unused imports (`bytes`, `errors`) from callers