### PR TITLE
refactor(http): extract generic select option builders for UI forms

### DIFF
--- a/services/merrymaker-go/internal/http/ui_alert_sinks_form.go
+++ b/services/merrymaker-go/internal/http/ui_alert_sinks_form.go
@@ -6,7 +6,6 @@ import (
 	"errors"
 	"fmt"
 	"net/http"
-	"sort"
 	"strconv"
 	"strings"
 	"time"
@@ -130,27 +129,18 @@ func buildSampleAlertJSON(baseURL string) string {
 
 // buildSecretOptions returns a slice of {Name, Selected} maps for the secrets select.
 func (h *UIHandlers) buildSecretOptions(ctx context.Context, selected []string) []map[string]any {
-	var out []map[string]any
 	if h.SecretSvc == nil {
-		return out
+		return nil
 	}
-	// Fetch up to 1000 for options; adjust if needed later
-	list, err := h.SecretSvc.List(ctx, 1000, 0)
-	if err != nil {
-		return out
-	}
-	// Sort by name (case-insensitive) for stable UX ordering
-	sort.Slice(list, func(i, j int) bool { return strings.ToLower(list[i].Name) < strings.ToLower(list[j].Name) })
 	set := map[string]struct{}{}
 	for _, s := range selected {
 		set[strings.TrimSpace(s)] = struct{}{}
 	}
-	out = make([]map[string]any, 0, len(list))
-	for _, s := range list {
-		_, sel := set[s.Name]
-		out = append(out, map[string]any{"Name": s.Name, "Selected": sel})
-	}
-	return out
+	opts := BuildSelectOptionsByName(ctx, h.SecretSvc.List, set,
+		func(s *model.Secret) string { return s.ID },
+		func(s *model.Secret) string { return s.Name },
+		1000)
+	return toNameOnlyOptionMaps(opts)
 }
 
 // parseSecretsFromForm collects non-empty unique secret names from a POSTed form.

--- a/services/merrymaker-go/internal/http/ui_base.go
+++ b/services/merrymaker-go/internal/http/ui_base.go
@@ -7,6 +7,7 @@ import (
 	"maps"
 	"net/http"
 	"net/url"
+	"sort"
 	"strconv"
 	"strings"
 
@@ -612,4 +613,83 @@ func (h *UIHandlers) logAndRenderTemplateError(w http.ResponseWriter, r *http.Re
 
 	// In production, show generic error
 	http.Error(w, "internal server error", http.StatusInternalServerError)
+}
+
+// SelectOption represents a dropdown/multiselect option.
+type SelectOption struct {
+	ID       string
+	Name     string
+	Selected bool
+}
+
+// BuildSelectOptions fetches entities via listFn, sorts by name (case-insensitive),
+// and produces SelectOption slices keyed by entity ID for use in HTML selects.
+// The selectedIDs map is keyed by entity ID; an entry present marks that option as selected.
+func BuildSelectOptions[E any](
+	ctx context.Context,
+	listFn func(context.Context, int, int) ([]E, error),
+	selectedIDs map[string]struct{},
+	idFn func(E) string,
+	nameFn func(E) string,
+	limit int,
+) []SelectOption {
+	list, err := listFn(ctx, limit, 0)
+	if err != nil {
+		return nil
+	}
+	sort.Slice(list, func(i, j int) bool {
+		return strings.ToLower(nameFn(list[i])) < strings.ToLower(nameFn(list[j]))
+	})
+	opts := make([]SelectOption, 0, len(list))
+	for _, item := range list {
+		id := idFn(item)
+		_, sel := selectedIDs[id]
+		opts = append(opts, SelectOption{
+			ID:       id,
+			Name:     nameFn(item),
+			Selected: sel,
+		})
+	}
+	return opts
+}
+
+// BuildSelectOptionsByName is like BuildSelectOptions but selects by name instead of ID.
+func BuildSelectOptionsByName[E any](
+	ctx context.Context,
+	listFn func(context.Context, int, int) ([]E, error),
+	selectedNames map[string]struct{},
+	idFn func(E) string,
+	nameFn func(E) string,
+	limit int,
+) []SelectOption {
+	list, err := listFn(ctx, limit, 0)
+	if err != nil {
+		return nil
+	}
+	sort.Slice(list, func(i, j int) bool {
+		return strings.ToLower(nameFn(list[i])) < strings.ToLower(nameFn(list[j]))
+	})
+	opts := make([]SelectOption, 0, len(list))
+	for _, item := range list {
+		name := nameFn(item)
+		_, sel := selectedNames[name]
+		opts = append(opts, SelectOption{
+			ID:       idFn(item),
+			Name:     name,
+			Selected: sel,
+		})
+	}
+	return opts
+}
+
+// toNameOnlyOptionMaps converts SelectOptions to a name-only map format for HTML templates.
+func toNameOnlyOptionMaps(opts []SelectOption) []map[string]any {
+	out := make([]map[string]any, 0, len(opts))
+	for _, o := range opts {
+		out = append(out, map[string]any{
+			"Name":     o.Name,
+			"Selected": o.Selected,
+		})
+	}
+	return out
 }

--- a/services/merrymaker-go/internal/http/ui_sites_form.go
+++ b/services/merrymaker-go/internal/http/ui_sites_form.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"errors"
 	"net/http"
-	"sort"
 	"strconv"
 	"strings"
 
@@ -18,44 +17,28 @@ const optionListLimit = 10000 // named to avoid magic numbers; adjust as needed
 
 // buildSourceOptions returns [{ID, Name, Selected}] for the source select.
 func (h *UIHandlers) buildSourceOptions(ctx context.Context, selectedID string) ([]map[string]any, error) {
-	var out []map[string]any
 	if h.SourceSvc == nil {
-		return out, errors.New("sources service unavailable")
+		return nil, errors.New("sources service unavailable")
 	}
-	list, err := h.SourceSvc.List(ctx, optionListLimit, 0)
-	if err != nil {
-		return out, err
-	}
-	sort.Slice(list, func(i, j int) bool { return strings.ToLower(list[i].Name) < strings.ToLower(list[j].Name) })
-	for _, s := range list {
-		out = append(out, map[string]any{
-			"ID":       s.ID,
-			"Name":     s.Name,
-			"Selected": s.ID == selectedID,
-		})
-	}
-	return out, nil
+	selected := map[string]struct{}{selectedID: {}}
+	opts := BuildSelectOptions(ctx, h.SourceSvc.List, selected,
+		func(s *model.Source) string { return s.ID },
+		func(s *model.Source) string { return s.Name },
+		optionListLimit)
+	return toOptionMaps(opts), nil
 }
 
 // buildAlertSinkOptions returns [{ID, Name, Selected}] for the alert sink select.
 func (h *UIHandlers) buildAlertSinkOptions(ctx context.Context, selectedID string) ([]map[string]any, error) {
-	var out []map[string]any
 	if h.Sinks == nil {
-		return out, errors.New("alert sinks service unavailable")
+		return nil, errors.New("alert sinks service unavailable")
 	}
-	list, err := h.Sinks.List(ctx, optionListLimit, 0)
-	if err != nil {
-		return out, err
-	}
-	sort.Slice(list, func(i, j int) bool { return strings.ToLower(list[i].Name) < strings.ToLower(list[j].Name) })
-	for _, s := range list {
-		out = append(out, map[string]any{
-			"ID":       s.ID,
-			"Name":     s.Name,
-			"Selected": s.ID == selectedID,
-		})
-	}
-	return out, nil
+	selected := map[string]struct{}{selectedID: {}}
+	opts := BuildSelectOptions(ctx, h.Sinks.List, selected,
+		func(s *model.HTTPAlertSink) string { return s.ID },
+		func(s *model.HTTPAlertSink) string { return s.Name },
+		optionListLimit)
+	return toOptionMaps(opts), nil
 }
 
 // renderSiteForm renders the Site create/edit form page with common framing data.
@@ -388,4 +371,17 @@ func (h *UIHandlers) SiteUpdate(w http.ResponseWriter, r *http.Request) {
 		SuccessURL: "/sites",
 		PageMeta:   PageMeta{Title: "Merrymaker - Edit Site", PageTitle: "Edit Site", CurrentPage: PageSiteForm},
 	})
+}
+
+// toOptionMaps converts SelectOptions to the legacy map format used by HTML templates.
+func toOptionMaps(opts []SelectOption) []map[string]any {
+	out := make([]map[string]any, 0, len(opts))
+	for _, o := range opts {
+		out = append(out, map[string]any{
+			"ID":       o.ID,
+			"Name":     o.Name,
+			"Selected": o.Selected,
+		})
+	}
+	return out
 }


### PR DESCRIPTION
Consolidate repetitive logic for populating dropdown and multiselect options across multiple form handlers into reusable generic functions. This reduces code duplication, centralizes sorting behavior, and improves type safety using Go generics.

- Add `BuildSelectOptions` and `BuildSelectOptionsByName` in `ui_base.go`
- Introduce `SelectOption` struct to standardize option representation
- Refactor `buildSecretOptions`, `buildSourceOptions`, and `buildAlertSinkOptions` to use new helpers
- Remove redundant `sort` imports from individual form files
- Add helper functions `toNameOnlyOptionMaps` and `toOptionMaps` for template compatibility