### PR TITLE
refactor(event-filter): make service immutable and remove runtime mutation

### DIFF
--- a/services/merrymaker-go/internal/service/event_filter.go
+++ b/services/merrymaker-go/internal/service/event_filter.go
@@ -1,43 +1,47 @@
 package service
 
 import (
-	"maps"
 	"strings"
-	"sync"
 
 	"github.com/target/mmk-ui-api/internal/domain/model"
 )
 
 // EventFilterService determines which events should be processed by the rules engine.
 type EventFilterService struct {
-	mu sync.RWMutex
-	// ProcessableEventTypes defines which event types should be processed by rules engine
-	ProcessableEventTypes map[string]bool
-	// normalized holds a lowercase-normalized view for efficient case-insensitive lookups
-	normalized map[string]bool
+	processableTypes map[string]bool // original-case keys (immutable after construction)
+	normalized       map[string]bool // lowercase-normalized view for case-insensitive lookups
 }
 
-// NewEventFilterService creates a new event filter service with default processable event model.
-func NewEventFilterService() *EventFilterService {
-	// Keep original-case keys for compatibility while also building a normalized map
-	orig := map[string]bool{
-		// CDP Network events used for domain extraction and analysis
-		"Network.requestWillBeSent": true,
-		"Network.responseReceived":  true,
+// NewEventFilterService creates a new event filter service.
+// Optionally pass default processable event types; if none provided, the built-in defaults are used.
+func NewEventFilterService(defaults ...string) *EventFilterService {
+	// Built-in defaults: CDP Network events used for domain extraction and analysis.
+	const defaultType1, defaultType2 = "Network.requestWillBeSent", "Network.responseReceived"
+
+	proces := make(map[string]bool, len(defaults)+2)
+	for _, t := range defaults {
+		proces[t] = true
 	}
-	s := &EventFilterService{ProcessableEventTypes: orig, normalized: make(map[string]bool, len(orig))}
-	for k, v := range orig {
-		s.normalized[strings.ToLower(k)] = v
+
+	if len(proces) == 0 {
+		proces[defaultType1] = true
+		proces[defaultType2] = true
 	}
-	return s
+
+	norm := make(map[string]bool, len(proces))
+	for k := range proces {
+		norm[strings.ToLower(k)] = true
+	}
+
+	return &EventFilterService{
+		processableTypes: proces,
+		normalized:       norm,
+	}
 }
 
 // ShouldProcessEvent determines if an event should be processed by the rules engine.
 func (s *EventFilterService) ShouldProcessEvent(eventType string) bool {
-	et := strings.ToLower(strings.TrimSpace(eventType))
-	s.mu.RLock()
-	defer s.mu.RUnlock()
-	return s.normalized[et]
+	return s.normalized[strings.ToLower(strings.TrimSpace(eventType))]
 }
 
 // ShouldProcessEvents determines which events in a batch should be processed.
@@ -63,64 +67,6 @@ func (s *EventFilterService) FilterProcessableEvents(events []model.RawEvent) []
 	}
 
 	return processableEvents
-}
-
-// AddProcessableEventType adds a new event type to the processable list.
-func (s *EventFilterService) AddProcessableEventType(eventType string) {
-	et := strings.TrimSpace(eventType)
-	if et == "" {
-		return
-	}
-	s.mu.Lock()
-	defer s.mu.Unlock()
-	s.ProcessableEventTypes[et] = true
-	s.normalized[strings.ToLower(et)] = true
-}
-
-// RemoveProcessableEventType removes an event type from the processable list.
-func (s *EventFilterService) RemoveProcessableEventType(eventType string) {
-	et := strings.TrimSpace(eventType)
-	if et == "" {
-		return
-	}
-	s.mu.Lock()
-	defer s.mu.Unlock()
-	delete(s.ProcessableEventTypes, et)
-	delete(s.normalized, strings.ToLower(et))
-}
-
-// SetProcessableEventType sets whether an event type should be processed.
-func (s *EventFilterService) SetProcessableEventType(eventType string, shouldProcess bool) {
-	et := strings.TrimSpace(eventType)
-	if et == "" {
-		return
-	}
-	s.mu.Lock()
-	defer s.mu.Unlock()
-	s.ProcessableEventTypes[et] = shouldProcess
-	s.normalized[strings.ToLower(et)] = shouldProcess
-}
-
-// GetProcessableEventTypes returns a copy of the current processable event model.
-func (s *EventFilterService) GetProcessableEventTypes() map[string]bool {
-	s.mu.RLock()
-	defer s.mu.RUnlock()
-	result := make(map[string]bool, len(s.ProcessableEventTypes))
-	maps.Copy(result, s.ProcessableEventTypes)
-	return result
-}
-
-// GetProcessableEventTypesList returns a list of event types that should be processed.
-func (s *EventFilterService) GetProcessableEventTypesList() []string {
-	s.mu.RLock()
-	defer s.mu.RUnlock()
-	var eventTypes []string
-	for eventType, shouldProcess := range s.ProcessableEventTypes {
-		if shouldProcess {
-			eventTypes = append(eventTypes, eventType)
-		}
-	}
-	return eventTypes
 }
 
 // EventFilterStats represents statistics about event filtering.

--- a/services/merrymaker-go/internal/service/event_filter_test.go
+++ b/services/merrymaker-go/internal/service/event_filter_test.go
@@ -15,7 +15,6 @@ func TestNewEventFilterService(t *testing.T) {
 	service := NewEventFilterService()
 
 	assert.NotNil(t, service)
-	assert.NotEmpty(t, service.ProcessableEventTypes)
 
 	// Check that default processable event types are set
 	expectedTypes := []string{
@@ -26,7 +25,7 @@ func TestNewEventFilterService(t *testing.T) {
 	for _, eventType := range expectedTypes {
 		assert.True(
 			t,
-			service.ProcessableEventTypes[eventType],
+			service.ShouldProcessEvent(eventType),
 			"Event type %s should be processable by default",
 			eventType,
 		)
@@ -155,57 +154,9 @@ func TestEventFilterService_FilterProcessableEvents(t *testing.T) {
 	assert.Equal(t, "Network.requestWillBeSent", processableEvents[0].Type)
 }
 
-func TestEventFilterService_AddRemoveProcessableEventType(t *testing.T) {
-	service := NewEventFilterService()
 
-	// Add a new processable event type
-	service.AddProcessableEventType("custom_event")
-	assert.True(t, service.ShouldProcessEvent("custom_event"))
 
-	// Remove an existing processable event type
-	service.RemoveProcessableEventType("domain_seen")
-	assert.False(t, service.ShouldProcessEvent("domain_seen"))
 
-	// Add back the removed event type
-	service.SetProcessableEventType("domain_seen", true)
-	assert.True(t, service.ShouldProcessEvent("domain_seen"))
-
-	// Disable an event type without removing it
-	service.SetProcessableEventType("domain_seen", false)
-	assert.False(t, service.ShouldProcessEvent("domain_seen"))
-}
-
-func TestEventFilterService_GetProcessableEventTypes(t *testing.T) {
-	service := NewEventFilterService()
-
-	eventTypes := service.GetProcessableEventTypes()
-
-	// Should return a copy, not the original map
-	assert.NotSame(t, &service.ProcessableEventTypes, &eventTypes)
-
-	// Should contain the same data
-	assert.Len(t, eventTypes, len(service.ProcessableEventTypes))
-	for eventType, shouldProcess := range service.ProcessableEventTypes {
-		assert.Equal(t, shouldProcess, eventTypes[eventType])
-	}
-}
-
-func TestEventFilterService_GetProcessableEventTypesList(t *testing.T) {
-	service := NewEventFilterService()
-
-	// Add a disabled event type
-	service.SetProcessableEventType("disabled_event", false)
-
-	eventTypesList := service.GetProcessableEventTypesList()
-
-	// Should only contain enabled event types
-	for _, eventType := range eventTypesList {
-		assert.True(t, service.ProcessableEventTypes[eventType], "Event type %s should be enabled", eventType)
-	}
-
-	// Should not contain disabled event types
-	assert.NotContains(t, eventTypesList, "disabled_event")
-}
 
 func TestEventFilterService_GetFilterStats(t *testing.T) {
 	service := NewEventFilterService()


### PR DESCRIPTION
Remove dynamic modification capabilities from EventFilterService to eliminate concurrency overhead and simplify the API. The filter is now configured at construction time via variadic arguments rather than through mutable methods.

- Remove `sync.RWMutex` and associated locking logic
- Delete `AddProcessableEventType`, `RemoveProcessableEventType`, and `SetProcessableEventType` methods
- Replace zero-argument constructor with one accepting default event types as variadic parameters
- Update tests to reflect the new immutable initialization pattern