### PR TITLE
fix: address GitHub security findings (CodeQL #38/#40, Dependabot #207)

### DIFF
--- a/services/merrymaker-go/internal/http/middleware_csrf.go
+++ b/services/merrymaker-go/internal/http/middleware_csrf.go
@@ -137,7 +137,7 @@ type csrfCookieParams struct {
 }
 
 // setCSRFCookie sets the CSRF token cookie.
-func setCSRFCookie(w http.ResponseWriter, r *http.Request, params csrfCookieParams) {
+func setCSRFCookie(w http.ResponseWriter, _ *http.Request, params csrfCookieParams) {
 	// Secure is always true — the app is served over HTTPS (direct TLS or
 	// a proxy terminating TLS). SameSite=Strict provides additional protection.
 	http.SetCookie(w, &http.Cookie{
@@ -150,24 +150,6 @@ func setCSRFCookie(w http.ResponseWriter, r *http.Request, params csrfCookiePara
 		SameSite: http.SameSiteStrictMode, // Strict for CSRF tokens
 		MaxAge:   3600 * 12,               // 12 hours
 	})
-}
-
-// isForwardedHTTPS checks if the request was forwarded over HTTPS.
-// Handles comma-separated values in X-Forwarded-Proto header.
-func isForwardedHTTPS(r *http.Request) bool {
-	xfProto := r.Header.Get("X-Forwarded-Proto")
-	if xfProto == "" {
-		return false
-	}
-
-	// Handle comma-separated values (e.g., "https,http")
-	for proto := range strings.SplitSeq(xfProto, ",") {
-		if strings.EqualFold(strings.TrimSpace(proto), "https") {
-			return true
-		}
-	}
-
-	return false
 }
 
 // validateCSRFToken validates the CSRF token from the request against the cookie value.

--- a/services/merrymaker-go/internal/http/middleware_csrf.go
+++ b/services/merrymaker-go/internal/http/middleware_csrf.go
@@ -138,16 +138,15 @@ type csrfCookieParams struct {
 
 // setCSRFCookie sets the CSRF token cookie.
 func setCSRFCookie(w http.ResponseWriter, r *http.Request, params csrfCookieParams) {
-	// Check if request is over HTTPS, accounting for proxies
-	isSecure := r.TLS != nil || isForwardedHTTPS(r)
-
+	// Secure is always true — the app is served over HTTPS (direct TLS or
+	// a proxy terminating TLS). SameSite=Strict provides additional protection.
 	http.SetCookie(w, &http.Cookie{
 		Name:     params.Name,
 		Value:    params.Token,
 		Path:     "/",
 		Domain:   params.Domain,
 		HttpOnly: false, // Must be readable by JavaScript for HTMX to include it
-		Secure:   isSecure,
+		Secure:   true,
 		SameSite: http.SameSiteStrictMode, // Strict for CSRF tokens
 		MaxAge:   3600 * 12,               // 12 hours
 	})

--- a/services/merrymaker-go/internal/http/ui_jobs.go
+++ b/services/merrymaker-go/internal/http/ui_jobs.go
@@ -1097,7 +1097,10 @@ func (h *UIHandlers) JobEvents(w http.ResponseWriter, r *http.Request) {
 
 	w.Header().Set("Content-Type", "text/html; charset=utf-8")
 	if templateErr := h.T.t.ExecuteTemplate(w, "job-events-fragment", data); templateErr != nil {
-		h.logger().ErrorContext(r.Context(), "JobEvents: template execution failed", "job_id", jobID, "error", templateErr)
+		h.logger().ErrorContext(
+			r.Context(), "JobEvents: template execution failed",
+			"job_id", jobID, "error", templateErr,
+		)
 		http.Error(w, "failed to render job events", http.StatusInternalServerError)
 	}
 }

--- a/services/merrymaker-go/internal/http/ui_jobs.go
+++ b/services/merrymaker-go/internal/http/ui_jobs.go
@@ -1116,7 +1116,10 @@ func (h *UIHandlers) JobEventDetails(w http.ResponseWriter, r *http.Request) {
 
 	events, err := h.EventSvc.GetByIDs(r.Context(), []string{eventID})
 	if err != nil {
-		h.logger().ErrorContext(r.Context(), "JobEventDetails: failed to fetch event", "event_id", eventID, "job_id", jobID, "error", err)
+		h.logger().ErrorContext(
+			r.Context(), "JobEventDetails: failed to fetch event",
+			"event_id", eventID, "job_id", jobID, "error", err,
+		)
 		http.Error(w, "failed to load event", http.StatusInternalServerError)
 		return
 	}

--- a/services/merrymaker-go/internal/http/ui_jobs.go
+++ b/services/merrymaker-go/internal/http/ui_jobs.go
@@ -1057,7 +1057,7 @@ func (h *UIHandlers) JobEvents(w http.ResponseWriter, r *http.Request) {
 
 	pageResp, err := h.fetchJobEvents(r.Context(), req.fetchParams)
 	if err != nil {
-		log.Printf("JobEvents: failed to list events for job %s: %v", jobID, err)
+		h.logger().ErrorContext(r.Context(), "JobEvents: failed to list events", "job_id", jobID, "error", err)
 		http.Error(w, "failed to load job events", http.StatusInternalServerError)
 		return
 	}
@@ -1097,7 +1097,7 @@ func (h *UIHandlers) JobEvents(w http.ResponseWriter, r *http.Request) {
 
 	w.Header().Set("Content-Type", "text/html; charset=utf-8")
 	if templateErr := h.T.t.ExecuteTemplate(w, "job-events-fragment", data); templateErr != nil {
-		log.Printf("JobEvents: template execution failed for job %s: %v", jobID, templateErr)
+		h.logger().ErrorContext(r.Context(), "JobEvents: template execution failed", "job_id", jobID, "error", templateErr)
 		http.Error(w, "failed to render job events", http.StatusInternalServerError)
 	}
 }
@@ -1113,7 +1113,7 @@ func (h *UIHandlers) JobEventDetails(w http.ResponseWriter, r *http.Request) {
 
 	events, err := h.EventSvc.GetByIDs(r.Context(), []string{eventID})
 	if err != nil {
-		log.Printf("JobEventDetails: failed to fetch event %s for job %s: %v", eventID, jobID, err)
+		h.logger().ErrorContext(r.Context(), "JobEventDetails: failed to fetch event", "event_id", eventID, "job_id", jobID, "error", err)
 		http.Error(w, "failed to load event", http.StatusInternalServerError)
 		return
 	}

--- a/services/puppeteer-worker/package-lock.json
+++ b/services/puppeteer-worker/package-lock.json
@@ -1430,15 +1430,6 @@
 				"node": ">=14"
 			}
 		},
-		"node_modules/@google-cloud/storage/node_modules/uuid": {
-			"version": "8.3.2",
-			"resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
-			"integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==",
-			"license": "MIT",
-			"bin": {
-				"uuid": "dist/bin/uuid"
-			}
-		},
 		"node_modules/@ioredis/commands": {
 			"version": "1.5.1",
 			"resolved": "https://registry.npmjs.org/@ioredis/commands/-/commands-1.5.1.tgz",
@@ -3372,7 +3363,7 @@
 			"version": "6.0.3",
 			"resolved": "https://registry.npmjs.org/typescript/-/typescript-6.0.3.tgz",
 			"integrity": "sha512-y2TvuxSZPDyQakkFRPZHKFm+KKVqIisdg9/CZwm9ftvKXLP8NRWj38/ODjNbr43SsoXqNuAisEf1GdCxqWcdBw==",
-			"devOptional": true,
+			"dev": true,
 			"license": "Apache-2.0",
 			"bin": {
 				"tsc": "bin/tsc",
@@ -3404,16 +3395,16 @@
 			"license": "MIT"
 		},
 		"node_modules/uuid": {
-			"version": "9.0.1",
-			"resolved": "https://registry.npmjs.org/uuid/-/uuid-9.0.1.tgz",
-			"integrity": "sha512-b+1eJOlsR9K8HJpow9Ok3fiWOWSIcIzXodvv0rQjVoOVNpWMpxf1wZNpt4y9h10odCNrqnYp1OBzRktckBe3sA==",
+			"version": "11.1.1",
+			"resolved": "https://registry.npmjs.org/uuid/-/uuid-11.1.1.tgz",
+			"integrity": "sha512-vIYxrBCC/N/K+Js3qSN88go7kIfNPssr/hHCesKCQNAjmgvYS2oqr69kIufEG+O4+PfezOH4EbIeHCfFov8ZgQ==",
 			"funding": [
 				"https://github.com/sponsors/broofa",
 				"https://github.com/sponsors/ctavan"
 			],
 			"license": "MIT",
 			"bin": {
-				"uuid": "dist/bin/uuid"
+				"uuid": "dist/esm/bin/uuid"
 			}
 		},
 		"node_modules/webdriver-bidi-protocol": {

--- a/services/puppeteer-worker/package.json
+++ b/services/puppeteer-worker/package.json
@@ -34,6 +34,9 @@
 		"tsx": "^4.22.3",
 		"typescript": "^6.0.3"
 	},
+	"overrides": {
+		"uuid": "^11.1.1"
+	},
 	"dependencies": {
 		"@aws-sdk/client-s3": "^3.1052.0",
 		"@aws-sdk/s3-request-presigner": "^3.1052.0",


### PR DESCRIPTION
## Summary

Addresses all open security findings from the GitHub Security tab.

### CodeQL #40 — Log injection (ERROR)
**File:** `services/merrymaker-go/internal/http/ui_jobs.go`

Replaced three `log.Printf` calls that interpolated user-controlled `jobID`/`eventID` path values into log message strings with structured `h.logger().ErrorContext`/`WarnContext` calls. Structured logging treats user values as typed fields, preventing newline-based log injection.

### CodeQL #38 — Cookie Secure attribute not set (WARNING)
**File:** `services/merrymaker-go/internal/http/middleware_csrf.go`

The CSRF token cookie previously set `Secure: isSecure` (dynamic, based on TLS/proxy detection). Changed to `Secure: true` unconditionally — the app is always served over HTTPS in production (direct TLS or proxy-terminated TLS).

### Dependabot #207 / CodeQL #43 #44 — `uuid < 11.1.1` (MEDIUM)
**File:** `services/puppeteer-worker/package.json`

Added an npm `overrides` entry to force `uuid@^11.1.1` across all transitive dependencies (`@google-cloud/storage` → `gaxios`, `teeny-request`). `npm audit` now reports 0 vulnerabilities.