### PR TITLE
refactor(http): standardize list-load logging

### DIFF
--- a/services/merrymaker-go/internal/http/ui_allowlist.go
+++ b/services/merrymaker-go/internal/http/ui_allowlist.go
@@ -20,8 +20,7 @@ func (h *UIHandlers) Allowlist(w http.ResponseWriter, r *http.Request) {
 			listOpts := model.DomainAllowlistListOptions{Limit: limit, Offset: offset}
 			items, err := h.AllowlistSvc.List(ctx, listOpts)
 			if err != nil {
-				h.logger().Error("failed to load allowlist for UI",
-					"error", err,
+				h.logLoadError(ctx, "failed to load allowlist for UI", err,
 					"page", pg.Page,
 					"page_size", pg.PageSize,
 				)

--- a/services/merrymaker-go/internal/http/ui_base.go
+++ b/services/merrymaker-go/internal/http/ui_base.go
@@ -270,6 +270,12 @@ func (h *UIHandlers) handleDelete(w http.ResponseWriter, r *http.Request, opts d
 	}
 }
 
+// logLoadError standardizes list-load error logging with request context.
+func (h *UIHandlers) logLoadError(ctx context.Context, message string, err error, attrs ...any) {
+	args := append([]any{"error", err}, attrs...)
+	h.logger().ErrorContext(ctx, message, args...)
+}
+
 // triggerToast sends a standardized HX-Trigger payload for toast notifications.
 // Centralizing this avoids repeating the boilerplate map construction across handlers.
 func triggerToast(w http.ResponseWriter, message, toastType string) {

--- a/services/merrymaker-go/internal/http/ui_dashboard.go
+++ b/services/merrymaker-go/internal/http/ui_dashboard.go
@@ -261,7 +261,7 @@ func (h *UIHandlers) Alerts(w http.ResponseWriter, r *http.Request) {
 		pageOpts{Page: pageNum, PageSize: pageSize},
 	)
 	if err != nil {
-		h.logger().Error("failed to load alerts for UI", "error", err)
+		h.logLoadError(r.Context(), "failed to load alerts for UI", err)
 		page.Error = true
 		page.ErrorMessage = errMsgUnableLoadAlerts
 		h.renderDashboardPage(w, r, page)

--- a/services/merrymaker-go/internal/http/ui_sites.go
+++ b/services/merrymaker-go/internal/http/ui_sites.go
@@ -134,8 +134,7 @@ func (h *UIHandlers) Sites(w http.ResponseWriter, r *http.Request) {
 			rows, err := h.listSiteRows(ctx, filters, pageBounds{Limit: limit, Offset: offset})
 			if err != nil {
 				// Log the error for operational visibility
-				h.logger().Error("failed to load sites for UI",
-					"error", err,
+				h.logLoadError(ctx, "failed to load sites for UI", err,
 					"query", filters.Q,
 					"enabled", filters.Enabled,
 					"scope", filters.Scope,


### PR DESCRIPTION
Standardizes the remaining direct list-load error logging calls through a shared helper on UIHandlers.

- adds logLoadError(ctx, message, err, attrs...)
- updates sites, dashboard, and allowlist loaders to use ErrorContext consistently

Tests: cd services/merrymaker-go && go test ./...

Fixes #175