### PR TITLE
chore: dep bumps + centralize delete-error handlers + test helpers + DRY puppeteer helpers

### DIFF
--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -51,7 +51,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - name: Setup Bun
         if: ${{ inputs.pre_build_cmd != '' }}
@@ -70,7 +70,7 @@ jobs:
 
       - name: Log in to Docker Hub
         if: ${{ inputs.push }}
-        uses: docker/login-action@af1e73f918a031802d376d3c8bbc3fe56130a9b0 # v4.4.0
+        uses: docker/login-action@abd2ef45e78c5afb21d64d4ca52ee8550d9572c7 # v4.5.1
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}

--- a/.github/workflows/merrymaker-go.yml
+++ b/.github/workflows/merrymaker-go.yml
@@ -29,7 +29,7 @@ jobs:
         working-directory: services/merrymaker-go
     steps:
       - name: Checkout
-        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - name: Setup Go
         uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0
@@ -64,7 +64,7 @@ jobs:
         working-directory: services/merrymaker-go
     steps:
       - name: Checkout
-        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - name: Setup Go
         uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0
@@ -129,7 +129,7 @@ jobs:
           --health-retries 10
     steps:
       - name: Checkout
-        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - name: Setup Go
         uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0
@@ -196,7 +196,7 @@ jobs:
         working-directory: services/merrymaker-go/frontend
     steps:
       - name: Checkout
-        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - name: Setup Bun
         uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2.2.0
@@ -235,7 +235,7 @@ jobs:
         working-directory: services/puppeteer-worker
     steps:
       - name: Checkout
-        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - name: Setup Node
         uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -24,7 +24,7 @@ jobs:
     name: govulncheck (Go)
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0
         with:
@@ -71,7 +71,7 @@ jobs:
       run:
         working-directory: services/puppeteer-worker
     steps:
-      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
@@ -96,7 +96,7 @@ jobs:
     name: Trivy FS (merrymaker-go)
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - name: Trivy filesystem scan
         uses: aquasecurity/trivy-action@ed142fd0673e97e23eac54620cfb913e5ce36c25 # v0.36.0
@@ -111,7 +111,7 @@ jobs:
 
       - name: Upload SARIF to GitHub Security tab
         if: always()
-        uses: github/codeql-action/upload-sarif@7188fc363630916deb702c7fdcf4e481b751f97a # v4.37.1
+        uses: github/codeql-action/upload-sarif@e4fba868fa4b1b91e1fdab776edc8cfbe6e9fb81 # v4.37.3
         with:
           sarif_file: trivy-go.sarif
           category: trivy-merrymaker-go
@@ -121,7 +121,7 @@ jobs:
     name: Trivy FS (puppeteer-worker)
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - name: Trivy filesystem scan
         uses: aquasecurity/trivy-action@ed142fd0673e97e23eac54620cfb913e5ce36c25 # v0.36.0
@@ -136,7 +136,7 @@ jobs:
 
       - name: Upload SARIF to GitHub Security tab
         if: always()
-        uses: github/codeql-action/upload-sarif@7188fc363630916deb702c7fdcf4e481b751f97a # v4.37.1
+        uses: github/codeql-action/upload-sarif@e4fba868fa4b1b91e1fdab776edc8cfbe6e9fb81 # v4.37.3
         with:
           sarif_file: trivy-puppeteer.sarif
           category: trivy-puppeteer-worker
@@ -150,10 +150,10 @@ jobs:
       matrix:
         language: [go, javascript-typescript]
     steps:
-      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - name: Initialize CodeQL
-        uses: github/codeql-action/init@7188fc363630916deb702c7fdcf4e481b751f97a # v4.37.1
+        uses: github/codeql-action/init@e4fba868fa4b1b91e1fdab776edc8cfbe6e9fb81 # v4.37.3
         with:
           languages: ${{ matrix.language }}
           queries: security-extended,security-and-quality
@@ -179,9 +179,9 @@ jobs:
           bun run build
 
       - name: Autobuild
-        uses: github/codeql-action/autobuild@7188fc363630916deb702c7fdcf4e481b751f97a # v4.37.1
+        uses: github/codeql-action/autobuild@e4fba868fa4b1b91e1fdab776edc8cfbe6e9fb81 # v4.37.3
 
       - name: Perform CodeQL analysis
-        uses: github/codeql-action/analyze@7188fc363630916deb702c7fdcf4e481b751f97a # v4.37.1
+        uses: github/codeql-action/analyze@e4fba868fa4b1b91e1fdab776edc8cfbe6e9fb81 # v4.37.3
         with:
           category: /language:${{ matrix.language }}

--- a/services/merrymaker-go/frontend/bun.lock
+++ b/services/merrymaker-go/frontend/bun.lock
@@ -8,10 +8,10 @@
         "@fontsource/inter": "^5.2.8",
         "@jmespath-community/jmespath": "1.3.0",
         "htmx.org": "2.0.10",
-        "lucide": "1.21.0",
+        "lucide": "1.25.0",
       },
       "devDependencies": {
-        "@biomejs/biome": "2.5.0",
+        "@biomejs/biome": "2.5.5",
         "@types/bun": "latest",
         "happy-dom": "^20.9.0",
       },
@@ -21,23 +21,23 @@
     },
   },
   "packages": {
-    "@biomejs/biome": ["@biomejs/biome@2.5.0", "", { "optionalDependencies": { "@biomejs/cli-darwin-arm64": "2.5.0", "@biomejs/cli-darwin-x64": "2.5.0", "@biomejs/cli-linux-arm64": "2.5.0", "@biomejs/cli-linux-arm64-musl": "2.5.0", "@biomejs/cli-linux-x64": "2.5.0", "@biomejs/cli-linux-x64-musl": "2.5.0", "@biomejs/cli-win32-arm64": "2.5.0", "@biomejs/cli-win32-x64": "2.5.0" }, "bin": { "biome": "bin/biome" } }, "sha512-4kURkd9hAPrdDM3C9n82ycYgx8hvQcW6MjKTEejruj8rK0N8P3OPpdy8BvI8kt3KWY4ycF5XtDOrktetEfhfuw=="],
+    "@biomejs/biome": ["@biomejs/biome@2.5.5", "", { "optionalDependencies": { "@biomejs/cli-darwin-arm64": "2.5.5", "@biomejs/cli-darwin-x64": "2.5.5", "@biomejs/cli-linux-arm64": "2.5.5", "@biomejs/cli-linux-arm64-musl": "2.5.5", "@biomejs/cli-linux-x64": "2.5.5", "@biomejs/cli-linux-x64-musl": "2.5.5", "@biomejs/cli-win32-arm64": "2.5.5", "@biomejs/cli-win32-x64": "2.5.5" }, "bin": { "biome": "bin/biome" } }, "sha512-r1S8nFsAG1MY+vJFZALzIvwXAJv6ejDQ0mxP21Tgr9YK3ZFtjrvbBwDdNhx1rUqvccEIeNg20cYCNzl6Cr69pQ=="],
 
-    "@biomejs/cli-darwin-arm64": ["@biomejs/cli-darwin-arm64@2.5.0", "", { "os": "darwin", "cpu": "arm64" }, "sha512-Mn3Fwi3SA5fgmfCPqmzpWF2DLZnms3BVAhM088nTnGrTZmHS3wwIjcoZPqpXeNgd3DrrLH6xp8vTLIBuJoZiXw=="],
+    "@biomejs/cli-darwin-arm64": ["@biomejs/cli-darwin-arm64@2.5.5", "", { "os": "darwin", "cpu": "arm64" }, "sha512-kUrAhXVWUrwmAUnV2iXSK7umxKFysTwvqK+Ty6ptUcLY/7T3SnCAjUowE4uvwaEej6nXZ7hu/dTtbokKdsPeag=="],
 
-    "@biomejs/cli-darwin-x64": ["@biomejs/cli-darwin-x64@2.5.0", "", { "os": "darwin", "cpu": "x64" }, "sha512-rg3VPL5P8mYro6pqlXYXuJWph21slVp3SZtAqWSrkZs40d2gTzYmHF8E/X1iTID25btmNKltNDJ926sqVBp7DQ=="],
+    "@biomejs/cli-darwin-x64": ["@biomejs/cli-darwin-x64@2.5.5", "", { "os": "darwin", "cpu": "x64" }, "sha512-DamiYc5bUYZ2uxlfc+RLEPtz1Abb6PO5eTbOkufLpSGwd/7AMQAdxhFYiXmwwkJL8IsT8S7GvdgwDHqaMFAvKw=="],
 
-    "@biomejs/cli-linux-arm64": ["@biomejs/cli-linux-arm64@2.5.0", "", { "os": "linux", "cpu": "arm64" }, "sha512-tl+LW8fdD96/xdeWtWwc82LIOc5CoY7N2AsogLTp5R4ECErYt+8Jl/N68ezN9vzSiqPTxw6vjcihoLPYKZHrlw=="],
+    "@biomejs/cli-linux-arm64": ["@biomejs/cli-linux-arm64@2.5.5", "", { "os": "linux", "cpu": "arm64" }, "sha512-lRKF/pH/1RiYiBKExi3TCZVAtvzEm77aifrvcNiDFrR9WxeAnDUjDnseb6y2XV85mjitLs6SILGm2XG77cHtSQ=="],
 
-    "@biomejs/cli-linux-arm64-musl": ["@biomejs/cli-linux-arm64-musl@2.5.0", "", { "os": "linux", "cpu": "arm64" }, "sha512-vQdM4oSGaf7ZNeGO9w5+Y8SBtyser9M6znxYbm7Ec8wInxJu1WiKxFYZW5Auj2d80bcVvefuGGRxoFOE0eee8g=="],
+    "@biomejs/cli-linux-arm64-musl": ["@biomejs/cli-linux-arm64-musl@2.5.5", "", { "os": "linux", "cpu": "arm64" }, "sha512-U4WMl/sy/E/Q73vf15VspakLRRs2LDFcCeBxJnQfXzssb88zpV6PJPaQ3ezhQ7H6Ht2/8bvuZeHgJWzmoxllZg=="],
 
-    "@biomejs/cli-linux-x64": ["@biomejs/cli-linux-x64@2.5.0", "", { "os": "linux", "cpu": "x64" }, "sha512-zpEGf4RQbFEh8Vt7OmavLyyOzRbtcE9osCqrS1kfvt8jDvxwhKXLSf7n0ebr/ov0RJ9ssP+lhs6C8a9WwFvrQA=="],
+    "@biomejs/cli-linux-x64": ["@biomejs/cli-linux-x64@2.5.5", "", { "os": "linux", "cpu": "x64" }, "sha512-H/O39nJEw/2Zm/fm7hrmxxoF8kK/aU1uCoPp70ruXVbomaAdLpJJnCmL11Q2JotT8QVHH06So04Oq53lCSwSwQ=="],
 
-    "@biomejs/cli-linux-x64-musl": ["@biomejs/cli-linux-x64-musl@2.5.0", "", { "os": "linux", "cpu": "x64" }, "sha512-+9hIcMngJ+yGUahXqZuZ8CoWKJE9SAZsFsM3QDvXpNsLbXZ9lqVzgBhOk/jTSYkOA0GLP9eu3teukqpLUojHMg=="],
+    "@biomejs/cli-linux-x64-musl": ["@biomejs/cli-linux-x64-musl@2.5.5", "", { "os": "linux", "cpu": "x64" }, "sha512-m7wC7tjX5Lrmo69dc4md8FeKpPU1NTCY1v7xUoQQ2vadWwNnBS0KZOG8471otFPHrTHihQJAjQPgMObpLvDe6A=="],
 
-    "@biomejs/cli-win32-arm64": ["@biomejs/cli-win32-arm64@2.5.0", "", { "os": "win32", "cpu": "arm64" }, "sha512-jB0wAvTLI4itx5VidqVUejPQFhRUxiZ9l9FvZ26D5fl6t3qme+ZB4PD3bTSeL1vZ8NI2Rx/zj6H9zcESuGHKGw=="],
+    "@biomejs/cli-win32-arm64": ["@biomejs/cli-win32-arm64@2.5.5", "", { "os": "win32", "cpu": "arm64" }, "sha512-7BryINPuYypLUAH3o/o5ZdgomJ4zn3EDR0ChZJst7n32S6ZhKbgHXuYydLu+YAnx59ehGFR0z/MG6qnzQi3Yyw=="],
 
-    "@biomejs/cli-win32-x64": ["@biomejs/cli-win32-x64@2.5.0", "", { "os": "win32", "cpu": "x64" }, "sha512-VT/lF+GId+67j8aDfLkxdxNoVApsPSTbyAtB3jJq0IWTrY77WXfbPfpngxq0bA6JCEv/7k8C9qWjDRKRznDlyw=="],
+    "@biomejs/cli-win32-x64": ["@biomejs/cli-win32-x64@2.5.5", "", { "os": "win32", "cpu": "x64" }, "sha512-bIBFo+n6MIxdNcVFy5CrurbKiZQiUciK3bt8+O9I4wjFZNTfXLpi+giq47522eXqW5NBc9ulx7dR1SlZKi2J5g=="],
 
     "@fontsource/inter": ["@fontsource/inter@5.2.8", "", {}, "sha512-P6r5WnJoKiNVV+zvW2xM13gNdFhAEpQ9dQJHt3naLvfg+LkF2ldgSLiF4T41lf1SQCM9QmkqPTn4TH568IRagg=="],
 
@@ -63,7 +63,7 @@
 
     "htmx.org": ["htmx.org@2.0.10", "", {}, "sha512-kdeJe7ZVwaS6QMz/ebBIVtZdpwen6L0OQ5GOhPV9MKBb196TCZeZu4yA7ZIQsaLKv7EpXz+So7KSXNuHXhj7Cw=="],
 
-    "lucide": ["lucide@1.21.0", "", {}, "sha512-m8g+tPjt1am9YBygKb36o2JOu5xOg7usbz0EORvPjn6MacIVy7desH1SNnV1ziMFHRGMGCcF5r1Jj80TxF2UTw=="],
+    "lucide": ["lucide@1.25.0", "", {}, "sha512-Pg/9Ga1xTbrnI6GY/7J9krIYmJIkAf3PkK6wPmsAeUtAQsBdGxs1+dfvLqjf9nPI5aFm9+VquT75JGpO3QXSpQ=="],
 
     "typescript": ["typescript@5.9.2", "", { "bin": { "tsc": "bin/tsc", "tsserver": "bin/tsserver" } }, "sha512-CWBzXQrc/qOkhidw1OzBTQuYRbfyxDXJMVJ1XNwUHGROVmuaeiEm3OslpZ1RV96d7SKKjZKrSJu3+t/xlw3R9A=="],
 

--- a/services/merrymaker-go/frontend/package.json
+++ b/services/merrymaker-go/frontend/package.json
@@ -14,7 +14,7 @@
     "format": "biome format --write"
   },
   "devDependencies": {
-    "@biomejs/biome": "2.5.0",
+    "@biomejs/biome": "2.5.5",
     "@types/bun": "latest",
     "happy-dom": "^20.9.0"
   },
@@ -25,6 +25,6 @@
     "@fontsource/inter": "^5.2.8",
     "@jmespath-community/jmespath": "1.3.0",
     "htmx.org": "2.0.10",
-    "lucide": "1.21.0"
+    "lucide": "1.25.0"
   }
 }

--- a/services/merrymaker-go/internal/http/testhelpers.go
+++ b/services/merrymaker-go/internal/http/testhelpers.go
@@ -6,12 +6,14 @@ import (
 	"encoding/json"
 	"net"
 	"net/http"
+	"net/http/httptest"
 	"os"
 	"strings"
 	"sync"
 	"testing"
 	"time"
 
+	"github.com/stretchr/testify/assert"
 	"github.com/target/mmk-ui-api/internal/testutil"
 )
 
@@ -164,4 +166,51 @@ func getTestHTTPClient() *http.Client {
 		}
 	})
 	return testHTTPClient
+}
+
+// ---------------------------------------------------------------------------
+// Higher-level assertion helpers (Issue #178)
+// ---------------------------------------------------------------------------
+
+// AssertBodyContains verifies that the response body contains all expected substrings.
+// Each missing substring is reported as a separate test failure with context.
+func AssertBodyContains(t *testing.T, body string, expected ...string) {
+	t.Helper()
+	for _, exp := range expected {
+		assert.Contains(t, body, exp, "expected body to contain: %s", exp)
+	}
+}
+
+// AssertHTMXResponse verifies an HTMX response: status 200 and a non-empty HX-Trigger header.
+func AssertHTMXResponse(t *testing.T, resp *httptest.ResponseRecorder, expectedTrigger string) {
+	t.Helper()
+	assert.Equal(t, http.StatusOK, resp.Code)
+	if expectedTrigger != "" {
+		assert.Contains(t, resp.Header().Get("Hx-Trigger"), expectedTrigger)
+	} else {
+		assert.NotEmpty(t, resp.Header().Get("Hx-Trigger"))
+	}
+}
+
+// AssertHTMXToast verifies that the response carries a showToast trigger.
+func AssertHTMXToast(t *testing.T, resp *httptest.ResponseRecorder, statusCode int) {
+	t.Helper()
+	assert.Equal(t, statusCode, resp.Code)
+	assert.Contains(t, resp.Header().Get("Hx-Trigger"), "showToast")
+}
+
+// AssertStatus verifies the response has the expected HTTP status code.
+func AssertStatus(t *testing.T, resp *httptest.ResponseRecorder, expectedCode int) {
+	t.Helper()
+	assert.Equal(t, expectedCode, resp.Code)
+}
+
+// AssertStatusAndBody verifies the response status code and that the body contains all expected substrings.
+func AssertStatusAndBody(t *testing.T, resp *httptest.ResponseRecorder, expectedCode int, expected ...string) {
+	t.Helper()
+	assert.Equal(t, expectedCode, resp.Code)
+	body := resp.Body.String()
+	for _, exp := range expected {
+		assert.Contains(t, body, exp, "expected body to contain: %s", exp)
+	}
 }

--- a/services/merrymaker-go/internal/http/ui_alert_sinks.go
+++ b/services/merrymaker-go/internal/http/ui_alert_sinks.go
@@ -112,9 +112,12 @@ func (h *UIHandlers) AlertSinkDelete(w http.ResponseWriter, r *http.Request) {
 			return h.Sinks.Delete(ctx, id)
 		},
 		RedirectPath: alertSinksBasePath,
-		OnError: func(w http.ResponseWriter, r *http.Request, err error) {
-			h.handleAlertSinkDeleteError(w, r, err)
-		},
+		OnError: DefaultDeleteOnError(DeleteOnErrorOpts{
+			Logger: h.logger(),
+			ListRender: func(w http.ResponseWriter, r *http.Request, msg string) {
+				h.renderAlertSinksListError(w, r, msg)
+			},
+		}),
 		OnSuccess: func(w http.ResponseWriter, r *http.Request, _ bool) {
 			if IsHTMX(r) {
 				HTMX(w).Redirect(alertSinksBasePath)
@@ -125,83 +128,34 @@ func (h *UIHandlers) AlertSinkDelete(w http.ResponseWriter, r *http.Request) {
 	})
 }
 
-// handleAlertSinkDeleteError handles errors during alert sink deletion.
-func (h *UIHandlers) handleAlertSinkDeleteError(w http.ResponseWriter, r *http.Request, err error) {
-	h.logger().Error("failed to delete alert sink", "error", err, "path", r.URL.Path)
-
+// renderAlertSinksListError re-renders the alert sinks list page with an error banner.
+func (h *UIHandlers) renderAlertSinksListError(w http.ResponseWriter, r *http.Request, msg string) {
 	page, pageSize := getPageParams(r.URL.Query())
 
+	builder := NewTemplateData(r, alertSinkListMeta()).
+		WithPagination(PaginationData{Page: page, PageSize: pageSize, BasePath: alertSinksBasePath}).
+		WithError(msg)
+
 	// Try to preserve list data for better UX
-	var additionalData map[string]any
-	if sinks, pagData := h.fetchAlertSinksForError(r.Context(), page, pageSize); sinks != nil {
-		additionalData = map[string]any{
-			"AlertSinks": sinks,
-			"HasPrev":    pagData.HasPrev,
-			"HasNext":    pagData.HasNext,
-			"StartIndex": pagData.StartIndex,
-			"EndIndex":   pagData.EndIndex,
-			"Page":       pagData.Page,
-			"PageSize":   pagData.PageSize,
+	if items, hasPrev, hasNext, start, end, err := paginate(
+		r.Context(),
+		pageOpts{Page: page, PageSize: pageSize},
+		func(ctx context.Context, limit, offset int) ([]*model.HTTPAlertSink, error) {
+			return h.Sinks.List(ctx, limit, offset)
+		},
+	); err == nil {
+		builder.With("AlertSinks", items).
+			With("HasPrev", hasPrev).With("HasNext", hasNext).
+			With("StartIndex", start).With("EndIndex", end)
+		if hasPrev {
+			builder.With("PrevURL", buildPageURL(alertSinksBasePath, r.URL.Query(), pageOpts{Page: page - 1, PageSize: pageSize}))
 		}
-		if pagData.HasPrev {
-			additionalData["PrevURL"] = buildPageURL(
-				alertSinksBasePath,
-				r.URL.Query(),
-				pageOpts{Page: page - 1, PageSize: pageSize},
-			)
-		}
-		if pagData.HasNext {
-			additionalData["NextURL"] = buildPageURL(
-				alertSinksBasePath,
-				r.URL.Query(),
-				pageOpts{Page: page + 1, PageSize: pageSize},
-			)
+		if hasNext {
+			builder.With("NextURL", buildPageURL(alertSinksBasePath, r.URL.Query(), pageOpts{Page: page + 1, PageSize: pageSize}))
 		}
 	}
 
-	// Determine appropriate status code based on error type
-	// Only set 409 Conflict for actual FK violations; otherwise use default (200 for HTMX)
-	status := DetermineErrorStatus(err)
-
-	// Use the error renderer for consistent error handling
-	RenderError(ErrorOpts{
-		W:          w,
-		R:          r,
-		Err:        err,
-		Renderer:   h.renderDashboardPage,
-		PageMeta:   alertSinkListMeta(),
-		Data:       additionalData,
-		StatusCode: status,
-	})
-}
-
-// fetchAlertSinksForError attempts to fetch alert sinks for error page display.
-func (h *UIHandlers) fetchAlertSinksForError(
-	ctx context.Context,
-	page, pageSize int,
-) ([]*model.HTTPAlertSink, PaginationData) {
-	limit := pageSize + 1
-	offset := (page - 1) * pageSize
-	sinks, err := h.Sinks.List(ctx, limit, offset)
-	if err != nil {
-		return nil, PaginationData{}
-	}
-
-	hasPrev := page > 1
-	hasNext := len(sinks) > pageSize
-	if hasNext {
-		sinks = sinks[:pageSize]
-	}
-
-	start, end := 0, 0
-	if len(sinks) > 0 {
-		start, end = offset+1, offset+len(sinks)
-	}
-
-	return sinks, PaginationData{
-		Page: page, PageSize: pageSize, HasPrev: hasPrev, HasNext: hasNext,
-		StartIndex: start, EndIndex: end, BasePath: alertSinksBasePath,
-	}
+	h.renderDashboardPage(w, r, builder.Build())
 }
 
 // AlertSinkTestFire handles test-firing an alert sink to validate configuration.

--- a/services/merrymaker-go/internal/http/ui_alert_sinks.go
+++ b/services/merrymaker-go/internal/http/ui_alert_sinks.go
@@ -148,10 +148,16 @@ func (h *UIHandlers) renderAlertSinksListError(w http.ResponseWriter, r *http.Re
 			With("HasPrev", hasPrev).With("HasNext", hasNext).
 			With("StartIndex", start).With("EndIndex", end)
 		if hasPrev {
-			builder.With("PrevURL", buildPageURL(alertSinksBasePath, r.URL.Query(), pageOpts{Page: page - 1, PageSize: pageSize}))
+			builder.With("PrevURL", buildPageURL(
+				alertSinksBasePath, r.URL.Query(),
+				pageOpts{Page: page - 1, PageSize: pageSize},
+			))
 		}
 		if hasNext {
-			builder.With("NextURL", buildPageURL(alertSinksBasePath, r.URL.Query(), pageOpts{Page: page + 1, PageSize: pageSize}))
+			builder.With("NextURL", buildPageURL(
+				alertSinksBasePath, r.URL.Query(),
+				pageOpts{Page: page + 1, PageSize: pageSize},
+			))
 		}
 	}
 

--- a/services/merrymaker-go/internal/http/ui_alerts_test.go
+++ b/services/merrymaker-go/internal/http/ui_alerts_test.go
@@ -484,11 +484,7 @@ func TestAlertViewHandler(t *testing.T) {
 	handlers.AlertView(w, req)
 
 	// Verify response
-	assert.Equal(t, http.StatusOK, w.Code)
-	body := w.Body.String()
-	assert.Contains(t, body, "Test Alert")
-	assert.Contains(t, body, "Test Site")
-	assert.Contains(t, body, "unknown_domain")
+	AssertStatusAndBody(t, w, http.StatusOK, "Test Alert", "Test Site", "unknown_domain")
 }
 
 func TestAlertResolve_RowTargetSuccess(t *testing.T) {
@@ -527,20 +523,15 @@ func TestAlertResolve_RowTargetSuccess(t *testing.T) {
 	w := httptest.NewRecorder()
 	handlers.AlertResolve(w, req)
 
-	assert.Equal(t, http.StatusOK, w.Code)
+	AssertHTMXResponse(t, w, "showToast")
 	assert.Equal(t, "text/html; charset=utf-8", w.Header().Get("Content-Type"))
 
 	trigger := w.Header().Get("Hx-Trigger")
-	require.NotEmpty(t, trigger)
-	require.Contains(t, trigger, "showToast")
 	require.Contains(t, trigger, "Alert marked as resolved.")
 	require.Contains(t, trigger, "\"type\":\"success\"")
 
-	body := w.Body.String()
-	assert.Contains(t, body, `id="alert-row-alert-123"`)
-	assert.Contains(t, body, "row-resolved")
-	assert.Contains(t, body, "Example Site")
-	assert.NotContains(t, body, "/alerts/alert-123/resolve")
+	AssertBodyContains(t, w.Body.String(), `id="alert-row-alert-123"`, "row-resolved", "Example Site")
+	assert.NotContains(t, w.Body.String(), "/alerts/alert-123/resolve")
 }
 
 func TestAlertResolve_RowTargetError(t *testing.T) {

--- a/services/merrymaker-go/internal/http/ui_base.go
+++ b/services/merrymaker-go/internal/http/ui_base.go
@@ -228,6 +228,65 @@ func paginate[T any](
 	return items, hasPrev, hasNext, startIndex, endIndex, nil
 }
 
+// DeleteOnErrorOpts configures the shared delete-error handler that replaces
+// repeated OnError callbacks across UI handlers.
+type DeleteOnErrorOpts struct {
+	// ErrorMessage returns a user-facing error message for the given error.
+	// If nil, a generic message is used.
+	ErrorMessage func(err error) string
+	// ListRender re-renders the full list page with an error banner.
+	// Called for non-HTMX requests (or when ToastOnly is false).
+	ListRender func(w http.ResponseWriter, r *http.Request, msg string)
+	// Logger is used to log the delete error. Optional.
+	Logger *slog.Logger
+}
+
+// DefaultDeleteOnError returns a standard OnError callback that:
+//   - For HTMX requests: triggers a toast notification and returns 204 (no swap).
+//   - For non-HTMX requests: delegates to ListRender to re-render the list with an error.
+func DefaultDeleteOnError(opts DeleteOnErrorOpts) func(http.ResponseWriter, *http.Request, error) {
+	return func(w http.ResponseWriter, r *http.Request, err error) {
+		msg := "Unable to delete resource. Please try again."
+		if opts.ErrorMessage != nil {
+			if m := opts.ErrorMessage(err); m != "" {
+				msg = m
+			}
+		}
+
+		if opts.Logger != nil {
+			opts.Logger.Error("delete failed", "error", err)
+		}
+
+		if IsHTMX(r) {
+			triggerToast(w, msg, "error")
+			w.WriteHeader(http.StatusNoContent)
+			return
+		}
+
+		if opts.ListRender != nil {
+			opts.ListRender(w, r, msg)
+			return
+		}
+
+		// Fallback: plain text error
+		http.Error(w, msg, http.StatusInternalServerError)
+	}
+}
+
+// DefaultDeleteOnSuccess returns a standard OnSuccess callback that:
+//   - For HTMX requests: triggers a success toast and returns 200.
+//   - For non-HTMX requests: redirects to redirectPath.
+func DefaultDeleteOnSuccess(redirectPath, successMsg string) func(http.ResponseWriter, *http.Request, bool) {
+	return func(w http.ResponseWriter, r *http.Request, _ bool) {
+		if IsHTMX(r) {
+			triggerToast(w, successMsg, "success")
+			w.WriteHeader(http.StatusOK)
+			return
+		}
+		http.Redirect(w, r, redirectPath, http.StatusSeeOther)
+	}
+}
+
 // deleteHandlerOpts encapsulates common delete-handling behavior for UI endpoints.
 type deleteHandlerOpts struct {
 	ServiceAvailable func() bool

--- a/services/merrymaker-go/internal/http/ui_jobs.go
+++ b/services/merrymaker-go/internal/http/ui_jobs.go
@@ -1387,8 +1387,8 @@ func (h *UIHandlers) JobDelete(w http.ResponseWriter, r *http.Request) {
 		},
 		OnError: DefaultDeleteOnError(DeleteOnErrorOpts{
 			ErrorMessage: getJobDeleteErrorMessage,
-			Logger:     h.logger(),
-			ListRender: h.renderJobsError,
+			Logger:       h.logger(),
+			ListRender:   h.renderJobsError,
 		}),
 		OnSuccess: DefaultDeleteOnSuccess("/jobs", "Job deleted successfully"),
 	})

--- a/services/merrymaker-go/internal/http/ui_jobs.go
+++ b/services/merrymaker-go/internal/http/ui_jobs.go
@@ -1386,9 +1386,7 @@ func (h *UIHandlers) JobDelete(w http.ResponseWriter, r *http.Request) {
 			return true, nil
 		},
 		OnError: DefaultDeleteOnError(DeleteOnErrorOpts{
-			ErrorMessage: func(err error) string {
-				return getJobDeleteErrorMessage(err)
-			},
+			ErrorMessage: getJobDeleteErrorMessage,
 			Logger:     h.logger(),
 			ListRender: h.renderJobsError,
 		}),

--- a/services/merrymaker-go/internal/http/ui_jobs.go
+++ b/services/merrymaker-go/internal/http/ui_jobs.go
@@ -1385,23 +1385,13 @@ func (h *UIHandlers) JobDelete(w http.ResponseWriter, r *http.Request) {
 			}
 			return true, nil
 		},
-		OnError: func(w http.ResponseWriter, r *http.Request, err error) {
-			errMsg := getJobDeleteErrorMessage(err)
-			if IsHTMX(r) {
-				triggerToast(w, errMsg, "error")
-				w.WriteHeader(http.StatusNoContent)
-				return
-			}
-			h.renderJobsError(w, r, errMsg)
-		},
-		OnSuccess: func(w http.ResponseWriter, r *http.Request, _ bool) {
-			if IsHTMX(r) {
-				triggerToast(w, "Job deleted successfully", "success")
-				w.WriteHeader(http.StatusOK)
-				return
-			}
-
-			http.Redirect(w, r, "/jobs", http.StatusSeeOther)
-		},
+		OnError: DefaultDeleteOnError(DeleteOnErrorOpts{
+			ErrorMessage: func(err error) string {
+				return getJobDeleteErrorMessage(err)
+			},
+			Logger:     h.logger(),
+			ListRender: h.renderJobsError,
+		}),
+		OnSuccess: DefaultDeleteOnSuccess("/jobs", "Job deleted successfully"),
 	})
 }

--- a/services/merrymaker-go/internal/http/ui_jobs_test.go
+++ b/services/merrymaker-go/internal/http/ui_jobs_test.go
@@ -265,16 +265,8 @@ func TestUIHandlers_JobView_ShowsBasicJobInfo(t *testing.T) {
 
 	h.JobView(w, r)
 
-	assert.Equal(t, http.StatusOK, w.Code)
-	body := w.Body.String()
-
-	// Check that basic job information is displayed
-	assert.Contains(t, body, "test-job-123")
-	assert.Contains(t, body, "browser")
-	assert.Contains(t, body, "Completed")  // Status badge shows "Completed" (capitalized)
-	assert.Contains(t, body, "50")         // priority
-	assert.Contains(t, body, "Test Run")   // Test run field in expanded details
-	assert.Contains(t, body, "badge-info") // Test badge
+	AssertStatusAndBody(t, w, http.StatusOK,
+		"test-job-123", "browser", "Completed", "50", "Test Run", "badge-info")
 }
 
 func TestUIHandlers_JobView_ShowsFailedJobWithError(t *testing.T) {
@@ -312,15 +304,9 @@ func TestUIHandlers_JobView_ShowsFailedJobWithError(t *testing.T) {
 
 	h.JobView(w, r)
 
-	assert.Equal(t, http.StatusOK, w.Code)
-	body := w.Body.String()
-
-	// Check that error information is displayed
-	assert.Contains(t, body, "failed-job-456")
-	assert.Contains(t, body, "rules")
-	assert.Contains(t, body, "failed")
-	assert.Contains(t, body, "Connection timeout")
-	assert.NotContains(t, body, "<strong>Test Run:</strong> Yes") // should not show for non-test jobs
+	AssertStatusAndBody(t, w, http.StatusOK,
+		"failed-job-456", "rules", "failed", "Connection timeout")
+	assert.NotContains(t, w.Body.String(), "<strong>Test Run:</strong> Yes") // should not show for non-test jobs
 }
 
 func TestUIHandlers_JobView_HandlesNonExistentJob(t *testing.T) {
@@ -426,18 +412,9 @@ func TestUIHandlers_JobView_ShowsSiteAndSourceContext(t *testing.T) {
 	body := w.Body.String()
 
 	// Check that Context section is displayed (in expanded details)
-	assert.Contains(t, body, "Context")
-
-	// Check Site information
-	assert.Contains(t, body, "Example Site")
-	assert.Contains(t, body, "production")
-	assert.Contains(t, body, "15 minutes")
-	assert.Contains(t, body, "/sites/"+siteID)
-
-	// Check Source information
-	assert.Contains(t, body, "Example Source")
-	assert.Contains(t, body, "Script Preview")
-	assert.Contains(t, body, "/sources?highlight="+sourceID)
+	AssertBodyContains(t, body, "Context",
+		"Example Site", "production", "15 minutes", "/sites/"+siteID,
+		"Example Source", "Script Preview", "/sources?highlight="+sourceID)
 }
 
 func TestUIHandlers_JobView_ShowsAlertDeliveryPanel(t *testing.T) {
@@ -501,16 +478,10 @@ func TestUIHandlers_JobView_ShowsAlertDeliveryPanel(t *testing.T) {
 
 	h.JobView(w, r)
 
-	assert.Equal(t, http.StatusOK, w.Code)
-	body := w.Body.String()
-
-	assert.Contains(t, body, "Alert Delivery Result")
-	assert.Contains(t, body, "Status: completed")
-	assert.Contains(t, body, "Attempt 1")
-	assert.Contains(t, body, "https://alerts.example.com/hook")
-	assert.Contains(t, body, "Content-Type")
-	assert.Contains(t, body, "&#34;alert&#34;: &#34;test&#34;")
-	assert.Contains(t, body, "X-Request-ID")
+	AssertStatusAndBody(t, w, http.StatusOK,
+		"Alert Delivery Result", "Status: completed", "Attempt 1",
+		"https://alerts.example.com/hook", "Content-Type",
+		"&#34;alert&#34;: &#34;test&#34;", "X-Request-ID")
 }
 
 func TestUIHandlers_JobView_HidesAttemptedWhenZero(t *testing.T) {

--- a/services/merrymaker-go/internal/http/ui_secrets.go
+++ b/services/merrymaker-go/internal/http/ui_secrets.go
@@ -557,42 +557,14 @@ func (h *UIHandlers) SecretDelete(w http.ResponseWriter, r *http.Request) {
 			return h.SecretSvc.Delete(ctx, id)
 		},
 		RedirectPath: "/secrets",
-		OnError: func(w http.ResponseWriter, r *http.Request, err error) {
-			h.handleSecretDeleteError(w, r, err)
-		},
-		OnSuccess: func(w http.ResponseWriter, r *http.Request, _ bool) {
-			// For HTMX requests, trigger success toast and return empty content to remove the row
-			if IsHTMX(r) {
-				triggerToast(w, "Secret deleted successfully", "success")
-				w.WriteHeader(http.StatusOK)
-				// Return empty content - the row will be swapped out with nothing (removed)
-				return
-			}
-			// For non-HTMX requests, redirect
-			http.Redirect(w, r, "/secrets", http.StatusSeeOther)
-		},
+		OnError: DefaultDeleteOnError(DeleteOnErrorOpts{
+			Logger: h.logger(),
+			ListRender: func(w http.ResponseWriter, r *http.Request, _ string) {
+				h.renderSecretListError(w, r, nil)
+			},
+		}),
+		OnSuccess: DefaultDeleteOnSuccess("/secrets", "Secret deleted successfully"),
 	})
-}
-
-// handleSecretDeleteError handles errors from secret deletion.
-// For HTMX requests, it triggers a toast notification and returns 204 No Content to prevent swap.
-// For non-HTMX requests, it re-renders the list with an error message.
-func (h *UIHandlers) handleSecretDeleteError(w http.ResponseWriter, r *http.Request, err error) {
-	// Get user-friendly error message
-	errMsg := processError(err, nil)
-	if errMsg == "" {
-		errMsg = "Unable to delete secret. Please try again."
-	}
-
-	// For HTMX requests, trigger error toast and keep the row (204 prevents swap)
-	if IsHTMX(r) {
-		triggerToast(w, errMsg, "error")
-		w.WriteHeader(http.StatusNoContent)
-		return
-	}
-
-	// For non-HTMX requests, re-render the list with error message
-	h.renderSecretListError(w, r, err)
 }
 
 // renderSecretListError renders the secret list page with an error message.

--- a/services/merrymaker-go/internal/http/ui_sites.go
+++ b/services/merrymaker-go/internal/http/ui_sites.go
@@ -171,8 +171,12 @@ func (h *UIHandlers) SiteDelete(w http.ResponseWriter, r *http.Request) {
 			return h.SiteSvc.Delete(ctx, id)
 		},
 		RedirectPath: "/sites",
-		OnError: func(w http.ResponseWriter, r *http.Request, _ error) {
-			h.renderSitesError(w, r, "Unable to delete site. It may be in use or have associated jobs.")
-		},
+		OnError: DefaultDeleteOnError(DeleteOnErrorOpts{
+			ErrorMessage: func(_ error) string {
+				return "Unable to delete site. It may be in use or have associated jobs."
+			},
+			Logger:     h.logger(),
+			ListRender: h.renderSitesError,
+		}),
 	})
 }

--- a/services/merrymaker-go/internal/http/ui_sites_list_test.go
+++ b/services/merrymaker-go/internal/http/ui_sites_list_test.go
@@ -97,15 +97,9 @@ func TestUIHandlers_Sites_ListWithNoFilters(t *testing.T) {
 
 		h.Sites(w, r)
 
-		assert.Equal(t, http.StatusOK, w.Code)
+		AssertStatusAndBody(t, w, http.StatusOK, site1.Name, site2.Name, site3.Name)
 		assert.Equal(t, "text/html; charset=utf-8", w.Header().Get("Content-Type"))
-		body := w.Body.String()
-
-		// Should contain all three sites
-		assert.Contains(t, body, site1.Name)
-		assert.Contains(t, body, site2.Name)
-		assert.Contains(t, body, site3.Name)
-		assert.NotContains(t, body, "No sites found")
+		assert.NotContains(t, w.Body.String(), "No sites found")
 	})
 }
 
@@ -151,14 +145,9 @@ func TestUIHandlers_Sites_ListWithEnabledFilter(t *testing.T) {
 
 		h.Sites(w, r)
 
-		assert.Equal(t, http.StatusOK, w.Code)
-		assert.Equal(t, "text/html; charset=utf-8", w.Header().Get("Content-Type"))
-		body := w.Body.String()
-
-		// Should contain only enabled site
-		assert.Contains(t, body, enabledSite.Name)
-		assert.NotContains(t, body, disabledSite.Name)
-		assert.NotContains(t, body, "No sites found")
+		AssertStatusAndBody(t, w, http.StatusOK, enabledSite.Name)
+		assert.NotContains(t, w.Body.String(), disabledSite.Name)
+		assert.NotContains(t, w.Body.String(), "No sites found")
 	})
 }
 
@@ -207,13 +196,8 @@ func TestUIHandlers_Sites_ListWithScopeFilter(t *testing.T) {
 
 		h.Sites(w, r)
 
-		assert.Equal(t, http.StatusOK, w.Code)
-		assert.Equal(t, "text/html; charset=utf-8", w.Header().Get("Content-Type"))
-		body := w.Body.String()
-
-		// Should contain only prod site
-		assert.Contains(t, body, prodSite.Name)
-		assert.NotContains(t, body, stagingSite.Name)
-		assert.NotContains(t, body, "No sites found")
+		AssertStatusAndBody(t, w, http.StatusOK, prodSite.Name)
+		assert.NotContains(t, w.Body.String(), stagingSite.Name)
+		assert.NotContains(t, w.Body.String(), "No sites found")
 	})
 }

--- a/services/puppeteer-worker/package-lock.json
+++ b/services/puppeteer-worker/package-lock.json
@@ -9,20 +9,20 @@
 			"version": "1.0.0",
 			"license": "ISC",
 			"dependencies": {
-				"@aws-sdk/client-s3": "^3.1084.0",
-				"@aws-sdk/s3-request-presigner": "^3.1084.0",
+				"@aws-sdk/client-s3": "^3.1094.0",
+				"@aws-sdk/s3-request-presigner": "^3.1094.0",
 				"@azure/storage-blob": "^12.33.0",
 				"@google-cloud/storage": "^7.21.0",
 				"ioredis": "^5.11.1",
 				"minio": "^8.0.7",
 				"puppeteer": "^25.3.0",
-				"undici": "^8.7.0",
+				"undici": "^8.8.0",
 				"yaml": "^2.9.0"
 			},
 			"devDependencies": {
-				"@biomejs/biome": "2.5.3",
+				"@biomejs/biome": "2.5.5",
 				"esbuild": "^0.28.1",
-				"tsx": "^4.23.0",
+				"tsx": "^4.23.1",
 				"typescript": "^7.0.2"
 			},
 			"engines": {
@@ -30,15 +30,15 @@
 			}
 		},
 		"node_modules/@aws-sdk/checksums": {
-			"version": "3.1000.16",
-			"resolved": "https://registry.npmjs.org/@aws-sdk/checksums/-/checksums-3.1000.16.tgz",
-			"integrity": "sha512-EKnvkXSmz3IpA99tCNuI+dLFXyZyClSm8zns9sB/elvkU+MTuomAs6toJMPMBf98/fICG/urXDkzGz0/c3yyAQ==",
+			"version": "3.1000.20",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/checksums/-/checksums-3.1000.20.tgz",
+			"integrity": "sha512-uc5PMNcLcs+UBSLGsRjbMZKi3mgnPSalXpABw9Xjo0DMrv4gjIa/E4a02yJsuU4FF6Tmvis/JgGdKNIOoN4DQw==",
 			"license": "Apache-2.0",
 			"dependencies": {
-				"@aws-sdk/core": "^3.975.1",
-				"@aws-sdk/types": "^3.974.0",
-				"@smithy/core": "^3.29.2",
-				"@smithy/types": "^4.16.0",
+				"@aws-sdk/core": "^3.977.0",
+				"@aws-sdk/types": "^3.974.2",
+				"@smithy/core": "^3.29.8",
+				"@smithy/types": "^4.16.1",
 				"tslib": "^2.6.2"
 			},
 			"engines": {
@@ -46,21 +46,21 @@
 			}
 		},
 		"node_modules/@aws-sdk/client-s3": {
-			"version": "3.1084.0",
-			"resolved": "https://registry.npmjs.org/@aws-sdk/client-s3/-/client-s3-3.1084.0.tgz",
-			"integrity": "sha512-W8KZlbU3vL4N0rZnXqryH5Ft3fkBnGypaorZmFxBoZRMGkwtvRBGiSnNXu1/1a/j/qZNwwt6LLNBWQQysB/pRg==",
+			"version": "3.1094.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/client-s3/-/client-s3-3.1094.0.tgz",
+			"integrity": "sha512-Qkz3HXW9bBajTO1Pgvbxkj2THliDnYPFBaJwIF1mDmnPe1E7reV9V/QJxBz14slIvdcU0tiyB+z37Qns0EY9Zg==",
 			"license": "Apache-2.0",
 			"dependencies": {
-				"@aws-sdk/checksums": "^3.1000.16",
-				"@aws-sdk/core": "^3.975.1",
-				"@aws-sdk/credential-provider-node": "^3.972.66",
-				"@aws-sdk/middleware-sdk-s3": "^3.972.62",
-				"@aws-sdk/signature-v4-multi-region": "^3.996.39",
-				"@aws-sdk/types": "^3.974.0",
-				"@smithy/core": "^3.29.2",
-				"@smithy/fetch-http-handler": "^5.6.4",
-				"@smithy/node-http-handler": "^4.9.4",
-				"@smithy/types": "^4.16.0",
+				"@aws-sdk/checksums": "^3.1000.19",
+				"@aws-sdk/core": "^3.976.0",
+				"@aws-sdk/credential-provider-node": "^3.972.71",
+				"@aws-sdk/middleware-sdk-s3": "^3.972.65",
+				"@aws-sdk/signature-v4-multi-region": "^3.996.41",
+				"@aws-sdk/types": "^3.974.2",
+				"@smithy/core": "^3.29.4",
+				"@smithy/fetch-http-handler": "^5.6.6",
+				"@smithy/node-http-handler": "^4.9.6",
+				"@smithy/types": "^4.16.1",
 				"tslib": "^2.6.2"
 			},
 			"engines": {
@@ -68,17 +68,17 @@
 			}
 		},
 		"node_modules/@aws-sdk/core": {
-			"version": "3.975.1",
-			"resolved": "https://registry.npmjs.org/@aws-sdk/core/-/core-3.975.1.tgz",
-			"integrity": "sha512-8qh/6EYb7hl/ZwVfQufhbMEZs1gQIc7GbdrIf4eprQJ7cv042+74nE6l3YDfyWNzb9iPXb8fRyYSHkNIk5eE6Q==",
+			"version": "3.977.1",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/core/-/core-3.977.1.tgz",
+			"integrity": "sha512-KVtQRtc00ES/y+Sc3vYXeP6pCIcNlBJCZOwvqSy8ZpVGmbM5+IG+AfhuTKQ2oXmIVqZJewaGMMpzPkywC6xg0w==",
 			"license": "Apache-2.0",
 			"dependencies": {
-				"@aws-sdk/types": "^3.974.0",
-				"@aws-sdk/xml-builder": "^3.972.34",
+				"@aws-sdk/types": "^3.974.2",
+				"@aws-sdk/xml-builder": "^3.972.37",
 				"@aws/lambda-invoke-store": "^0.3.0",
-				"@smithy/core": "^3.29.2",
-				"@smithy/signature-v4": "^5.6.3",
-				"@smithy/types": "^4.16.0",
+				"@smithy/core": "^3.29.8",
+				"@smithy/signature-v4": "^5.6.9",
+				"@smithy/types": "^4.16.1",
 				"bowser": "^2.11.0",
 				"tslib": "^2.6.2"
 			},
@@ -87,15 +87,15 @@
 			}
 		},
 		"node_modules/@aws-sdk/credential-provider-env": {
-			"version": "3.972.57",
-			"resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-env/-/credential-provider-env-3.972.57.tgz",
-			"integrity": "sha512-1RfJaF7SW1TOnvNGU7kaYjwUf5H3sfm+synGH1bHhRlqcnxCt3szebH3dmKEyY4tuGcbQ6ffzUT89cRitBV8OQ==",
+			"version": "3.972.61",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-env/-/credential-provider-env-3.972.61.tgz",
+			"integrity": "sha512-qihs2ekMb89Nxd2JenCgVFhjbkb3EIo7HEBCBzyZACKVJdrLUZBLOmAE3xr0Sayml8n/jZSzwO/IufIiIzO7PQ==",
 			"license": "Apache-2.0",
 			"dependencies": {
-				"@aws-sdk/core": "^3.975.1",
-				"@aws-sdk/types": "^3.974.0",
-				"@smithy/core": "^3.29.2",
-				"@smithy/types": "^4.16.0",
+				"@aws-sdk/core": "^3.977.0",
+				"@aws-sdk/types": "^3.974.2",
+				"@smithy/core": "^3.29.8",
+				"@smithy/types": "^4.16.1",
 				"tslib": "^2.6.2"
 			},
 			"engines": {
@@ -103,17 +103,17 @@
 			}
 		},
 		"node_modules/@aws-sdk/credential-provider-http": {
-			"version": "3.972.59",
-			"resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-http/-/credential-provider-http-3.972.59.tgz",
-			"integrity": "sha512-sRCkpTiFnCdQvuaRVjQ6SVoHu6i7RUpurVo1c4F81HWhPvUJ7Wdp5MNtSdX1O29CNXc8em3O5m52hCjVtAD9SA==",
+			"version": "3.972.63",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-http/-/credential-provider-http-3.972.63.tgz",
+			"integrity": "sha512-yfozsS8wkWZEi/n6IsrodcFKBWZ0iNAezhJbTReMNc0z1Px17qdeAeuL1/wziCAmCZyXiW7QzP75ggJkBQv8jQ==",
 			"license": "Apache-2.0",
 			"dependencies": {
-				"@aws-sdk/core": "^3.975.1",
-				"@aws-sdk/types": "^3.974.0",
-				"@smithy/core": "^3.29.2",
-				"@smithy/fetch-http-handler": "^5.6.4",
-				"@smithy/node-http-handler": "^4.9.4",
-				"@smithy/types": "^4.16.0",
+				"@aws-sdk/core": "^3.977.0",
+				"@aws-sdk/types": "^3.974.2",
+				"@smithy/core": "^3.29.8",
+				"@smithy/fetch-http-handler": "^5.6.10",
+				"@smithy/node-http-handler": "^4.9.10",
+				"@smithy/types": "^4.16.1",
 				"tslib": "^2.6.2"
 			},
 			"engines": {
@@ -121,23 +121,23 @@
 			}
 		},
 		"node_modules/@aws-sdk/credential-provider-ini": {
-			"version": "3.973.1",
-			"resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-ini/-/credential-provider-ini-3.973.1.tgz",
-			"integrity": "sha512-6d8H6ZAh3ZPKZ6fe1nG2OWeZEZPtt9ravoD1dezPdPtsSkJRoxGAnFSHwKT3E/Te6fHE30zRzjV6TD12rvF6yQ==",
+			"version": "3.973.6",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-ini/-/credential-provider-ini-3.973.6.tgz",
+			"integrity": "sha512-jGLTW1bj148GL/6/IMlfY2fMYS9FtHOG+NahkFD4y0qkzYudNUahelxryY68/HGMslYuHClk1XaS/3b3eJzEkg==",
 			"license": "Apache-2.0",
 			"dependencies": {
-				"@aws-sdk/core": "^3.975.1",
-				"@aws-sdk/credential-provider-env": "^3.972.57",
-				"@aws-sdk/credential-provider-http": "^3.972.59",
-				"@aws-sdk/credential-provider-login": "^3.972.63",
-				"@aws-sdk/credential-provider-process": "^3.972.57",
-				"@aws-sdk/credential-provider-sso": "^3.973.1",
-				"@aws-sdk/credential-provider-web-identity": "^3.972.63",
-				"@aws-sdk/nested-clients": "^3.997.31",
-				"@aws-sdk/types": "^3.974.0",
-				"@smithy/core": "^3.29.2",
-				"@smithy/credential-provider-imds": "^4.4.7",
-				"@smithy/types": "^4.16.0",
+				"@aws-sdk/core": "^3.977.0",
+				"@aws-sdk/credential-provider-env": "^3.972.61",
+				"@aws-sdk/credential-provider-http": "^3.972.63",
+				"@aws-sdk/credential-provider-login": "^3.972.68",
+				"@aws-sdk/credential-provider-process": "^3.972.61",
+				"@aws-sdk/credential-provider-sso": "^3.973.5",
+				"@aws-sdk/credential-provider-web-identity": "^3.972.67",
+				"@aws-sdk/nested-clients": "^3.997.35",
+				"@aws-sdk/types": "^3.974.2",
+				"@smithy/core": "^3.29.8",
+				"@smithy/credential-provider-imds": "^4.4.13",
+				"@smithy/types": "^4.16.1",
 				"tslib": "^2.6.2"
 			},
 			"engines": {
@@ -145,16 +145,16 @@
 			}
 		},
 		"node_modules/@aws-sdk/credential-provider-login": {
-			"version": "3.972.63",
-			"resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-login/-/credential-provider-login-3.972.63.tgz",
-			"integrity": "sha512-GREWRrMj0XnNKMaVa/Mauoaui26qBEHu71WWqXbwZOu/jFQOnPZjTf7u0KtGKC8VGa6VUs9kDWGgocrKNLS9vw==",
+			"version": "3.972.68",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-login/-/credential-provider-login-3.972.68.tgz",
+			"integrity": "sha512-w6tNci6g7RqFpLhj1f5xseBvaNojb4Pkgp5Jp5apl9hrJtaf2AA+rX9+qlhlWUK6kcyAFYPA7emO+55zj+S98Q==",
 			"license": "Apache-2.0",
 			"dependencies": {
-				"@aws-sdk/core": "^3.975.1",
-				"@aws-sdk/nested-clients": "^3.997.31",
-				"@aws-sdk/types": "^3.974.0",
-				"@smithy/core": "^3.29.2",
-				"@smithy/types": "^4.16.0",
+				"@aws-sdk/core": "^3.977.0",
+				"@aws-sdk/nested-clients": "^3.997.35",
+				"@aws-sdk/types": "^3.974.2",
+				"@smithy/core": "^3.29.8",
+				"@smithy/types": "^4.16.1",
 				"tslib": "^2.6.2"
 			},
 			"engines": {
@@ -162,21 +162,21 @@
 			}
 		},
 		"node_modules/@aws-sdk/credential-provider-node": {
-			"version": "3.972.66",
-			"resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-node/-/credential-provider-node-3.972.66.tgz",
-			"integrity": "sha512-f+qjRXZpz7sgzbc4QB+6nLKfyKFgRRXzWdXbsKPv/VhVRyHsDyq4yBWC/B75BAJpFIcUeI2XR/3gdWJ677zB4A==",
+			"version": "3.972.72",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-node/-/credential-provider-node-3.972.72.tgz",
+			"integrity": "sha512-blQ7F5QGzylnzeh5549zQLoCAiMHkXFLjFovEMaVy4b2X8JhUu+u9NXro1hyK95YHdVFNmBHKs2hIHtZchxKlQ==",
 			"license": "Apache-2.0",
 			"dependencies": {
-				"@aws-sdk/credential-provider-env": "^3.972.57",
-				"@aws-sdk/credential-provider-http": "^3.972.59",
-				"@aws-sdk/credential-provider-ini": "^3.973.1",
-				"@aws-sdk/credential-provider-process": "^3.972.57",
-				"@aws-sdk/credential-provider-sso": "^3.973.1",
-				"@aws-sdk/credential-provider-web-identity": "^3.972.63",
-				"@aws-sdk/types": "^3.974.0",
-				"@smithy/core": "^3.29.2",
-				"@smithy/credential-provider-imds": "^4.4.7",
-				"@smithy/types": "^4.16.0",
+				"@aws-sdk/credential-provider-env": "^3.972.61",
+				"@aws-sdk/credential-provider-http": "^3.972.63",
+				"@aws-sdk/credential-provider-ini": "^3.973.6",
+				"@aws-sdk/credential-provider-process": "^3.972.61",
+				"@aws-sdk/credential-provider-sso": "^3.973.5",
+				"@aws-sdk/credential-provider-web-identity": "^3.972.67",
+				"@aws-sdk/types": "^3.974.2",
+				"@smithy/core": "^3.29.8",
+				"@smithy/credential-provider-imds": "^4.4.13",
+				"@smithy/types": "^4.16.1",
 				"tslib": "^2.6.2"
 			},
 			"engines": {
@@ -184,15 +184,15 @@
 			}
 		},
 		"node_modules/@aws-sdk/credential-provider-process": {
-			"version": "3.972.57",
-			"resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-process/-/credential-provider-process-3.972.57.tgz",
-			"integrity": "sha512-TiVQhuU0pbhIZAUZacbPHMyzrIdiH+lnx+PMY/Pu/b93dJrq3wdZwzUJ0TPpvNxaqbHsxJvQZW3/h/beLiKq7Q==",
+			"version": "3.972.61",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-process/-/credential-provider-process-3.972.61.tgz",
+			"integrity": "sha512-xzRuj+fUVO4nkafKQJVKAF97kGpeQbfjuwmRrtGZNf42/1dkmcz6o7dswBy7alY0htQn5sCL1GWQYEykviWZkA==",
 			"license": "Apache-2.0",
 			"dependencies": {
-				"@aws-sdk/core": "^3.975.1",
-				"@aws-sdk/types": "^3.974.0",
-				"@smithy/core": "^3.29.2",
-				"@smithy/types": "^4.16.0",
+				"@aws-sdk/core": "^3.977.0",
+				"@aws-sdk/types": "^3.974.2",
+				"@smithy/core": "^3.29.8",
+				"@smithy/types": "^4.16.1",
 				"tslib": "^2.6.2"
 			},
 			"engines": {
@@ -200,17 +200,17 @@
 			}
 		},
 		"node_modules/@aws-sdk/credential-provider-sso": {
-			"version": "3.973.1",
-			"resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-sso/-/credential-provider-sso-3.973.1.tgz",
-			"integrity": "sha512-3foTZUJ4821Ij60X7K3NJroygiZLnbBmarN+T//O2cjkISan90zElN3NBmgSlDrTQ7Gs6z/yO8V7h60QNcDZHQ==",
+			"version": "3.973.5",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-sso/-/credential-provider-sso-3.973.5.tgz",
+			"integrity": "sha512-fZRjjWhLFelsDoOYjqShQTrIGYC3Pf9Mx9Czf+1ikfQDgktxjze33dVo1q1/ZQ+T0qbtejVoHNHrfD5aJVpv/w==",
 			"license": "Apache-2.0",
 			"dependencies": {
-				"@aws-sdk/core": "^3.975.1",
-				"@aws-sdk/nested-clients": "^3.997.31",
-				"@aws-sdk/token-providers": "3.1083.0",
-				"@aws-sdk/types": "^3.974.0",
-				"@smithy/core": "^3.29.2",
-				"@smithy/types": "^4.16.0",
+				"@aws-sdk/core": "^3.977.0",
+				"@aws-sdk/nested-clients": "^3.997.35",
+				"@aws-sdk/token-providers": "3.1095.0",
+				"@aws-sdk/types": "^3.974.2",
+				"@smithy/core": "^3.29.8",
+				"@smithy/types": "^4.16.1",
 				"tslib": "^2.6.2"
 			},
 			"engines": {
@@ -218,16 +218,16 @@
 			}
 		},
 		"node_modules/@aws-sdk/credential-provider-web-identity": {
-			"version": "3.972.63",
-			"resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-web-identity/-/credential-provider-web-identity-3.972.63.tgz",
-			"integrity": "sha512-8qZLFhM69eKcS37m459ctPR05Qimycm/74OPVioe6wNZabMT54GYhwBju0+J656RkMasNSawWQu+c8CmBe3TUQ==",
+			"version": "3.972.67",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-web-identity/-/credential-provider-web-identity-3.972.67.tgz",
+			"integrity": "sha512-FTNZ05gkPBA6CKbU3N4zPgybV+stdazwMOya75CmGdcJL7p8Fw/BdHP8WVxJd0mvzyPK2cg/C3gli58Ir4HgCw==",
 			"license": "Apache-2.0",
 			"dependencies": {
-				"@aws-sdk/core": "^3.975.1",
-				"@aws-sdk/nested-clients": "^3.997.31",
-				"@aws-sdk/types": "^3.974.0",
-				"@smithy/core": "^3.29.2",
-				"@smithy/types": "^4.16.0",
+				"@aws-sdk/core": "^3.977.0",
+				"@aws-sdk/nested-clients": "^3.997.35",
+				"@aws-sdk/types": "^3.974.2",
+				"@smithy/core": "^3.29.8",
+				"@smithy/types": "^4.16.1",
 				"tslib": "^2.6.2"
 			},
 			"engines": {
@@ -235,16 +235,16 @@
 			}
 		},
 		"node_modules/@aws-sdk/middleware-sdk-s3": {
-			"version": "3.972.62",
-			"resolved": "https://registry.npmjs.org/@aws-sdk/middleware-sdk-s3/-/middleware-sdk-s3-3.972.62.tgz",
-			"integrity": "sha512-k8JJwYXVYlOOjWnPZDThQS1xDFJgi5Dokt73qFlDtrZAbdcint5aIdjB9XgJAAQVP5OoqcefQmh1FYXiPpvsvw==",
+			"version": "3.972.66",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/middleware-sdk-s3/-/middleware-sdk-s3-3.972.66.tgz",
+			"integrity": "sha512-sTZKP1+SvyzWc/3alO8AM/PUiEzDCmn2P/KOcFFSk2UKzKZkB5ZxXdlHVtACE7DHaMFvx6DY0bognwHa1qTv4g==",
 			"license": "Apache-2.0",
 			"dependencies": {
-				"@aws-sdk/core": "^3.975.1",
-				"@aws-sdk/signature-v4-multi-region": "^3.996.39",
-				"@aws-sdk/types": "^3.974.0",
-				"@smithy/core": "^3.29.2",
-				"@smithy/types": "^4.16.0",
+				"@aws-sdk/core": "^3.977.0",
+				"@aws-sdk/signature-v4-multi-region": "^3.996.42",
+				"@aws-sdk/types": "^3.974.2",
+				"@smithy/core": "^3.29.8",
+				"@smithy/types": "^4.16.1",
 				"tslib": "^2.6.2"
 			},
 			"engines": {
@@ -252,18 +252,18 @@
 			}
 		},
 		"node_modules/@aws-sdk/nested-clients": {
-			"version": "3.997.31",
-			"resolved": "https://registry.npmjs.org/@aws-sdk/nested-clients/-/nested-clients-3.997.31.tgz",
-			"integrity": "sha512-BDHTpwcsZHEBNEJzOg/B1BkFYJxAXY50dau/NyVWs3d51F0WgIUGSWZot/Os+N3KpDhXeaXnz37mWffAvduREw==",
+			"version": "3.997.35",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/nested-clients/-/nested-clients-3.997.35.tgz",
+			"integrity": "sha512-2MJfseVG/aXvIyOIBlYA/Oaf6qFDdsu4D8RKsEUdOQpVuLaor0BdxIBBtJLBNQQEe6Ku3YMvLljwb1MwVUpzRw==",
 			"license": "Apache-2.0",
 			"dependencies": {
-				"@aws-sdk/core": "^3.975.1",
-				"@aws-sdk/signature-v4-multi-region": "^3.996.39",
-				"@aws-sdk/types": "^3.974.0",
-				"@smithy/core": "^3.29.2",
-				"@smithy/fetch-http-handler": "^5.6.4",
-				"@smithy/node-http-handler": "^4.9.4",
-				"@smithy/types": "^4.16.0",
+				"@aws-sdk/core": "^3.977.0",
+				"@aws-sdk/signature-v4-multi-region": "^3.996.42",
+				"@aws-sdk/types": "^3.974.2",
+				"@smithy/core": "^3.29.8",
+				"@smithy/fetch-http-handler": "^5.6.10",
+				"@smithy/node-http-handler": "^4.9.10",
+				"@smithy/types": "^4.16.1",
 				"tslib": "^2.6.2"
 			},
 			"engines": {
@@ -271,16 +271,16 @@
 			}
 		},
 		"node_modules/@aws-sdk/s3-request-presigner": {
-			"version": "3.1084.0",
-			"resolved": "https://registry.npmjs.org/@aws-sdk/s3-request-presigner/-/s3-request-presigner-3.1084.0.tgz",
-			"integrity": "sha512-2IwtgX/5/G7rKxc9cp1eGdrpJrZ0sl88bKavjCWGSkMPxFmtbSnms+guAhSltZHjJbT34rfudRwW30aKtLOqbA==",
+			"version": "3.1094.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/s3-request-presigner/-/s3-request-presigner-3.1094.0.tgz",
+			"integrity": "sha512-7kG3C37tPWEpz8TyHslFhi2TrQ10und7ijerO0V/Ljq2uxBWVi4SFcol8yp2gM09HYzMnkWCfOxAKJZ2OZvClw==",
 			"license": "Apache-2.0",
 			"dependencies": {
-				"@aws-sdk/core": "^3.975.1",
-				"@aws-sdk/signature-v4-multi-region": "^3.996.39",
-				"@aws-sdk/types": "^3.974.0",
-				"@smithy/core": "^3.29.2",
-				"@smithy/types": "^4.16.0",
+				"@aws-sdk/core": "^3.976.0",
+				"@aws-sdk/signature-v4-multi-region": "^3.996.41",
+				"@aws-sdk/types": "^3.974.2",
+				"@smithy/core": "^3.29.4",
+				"@smithy/types": "^4.16.1",
 				"tslib": "^2.6.2"
 			},
 			"engines": {
@@ -288,14 +288,14 @@
 			}
 		},
 		"node_modules/@aws-sdk/signature-v4-multi-region": {
-			"version": "3.996.39",
-			"resolved": "https://registry.npmjs.org/@aws-sdk/signature-v4-multi-region/-/signature-v4-multi-region-3.996.39.tgz",
-			"integrity": "sha512-8+srXqYIF8KYMLC4FxMLEM5Ek7kUNibJu1R4m8/fUhhNYIZZz26oGtKkCr8I/HiG2fFQxBvaGgQZT4/mqRCSnA==",
+			"version": "3.996.42",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/signature-v4-multi-region/-/signature-v4-multi-region-3.996.42.tgz",
+			"integrity": "sha512-DBV4naZP6HYBlAvPpoQzOP12Wvfou/5rN8yJPXjBTBylU5qwCbh/tXr2MddHoIjgoRkEl/eS+IljiUqvmwey1Q==",
 			"license": "Apache-2.0",
 			"dependencies": {
-				"@aws-sdk/types": "^3.974.0",
-				"@smithy/signature-v4": "^5.6.3",
-				"@smithy/types": "^4.16.0",
+				"@aws-sdk/types": "^3.974.2",
+				"@smithy/signature-v4": "^5.6.9",
+				"@smithy/types": "^4.16.1",
 				"tslib": "^2.6.2"
 			},
 			"engines": {
@@ -303,16 +303,16 @@
 			}
 		},
 		"node_modules/@aws-sdk/token-providers": {
-			"version": "3.1083.0",
-			"resolved": "https://registry.npmjs.org/@aws-sdk/token-providers/-/token-providers-3.1083.0.tgz",
-			"integrity": "sha512-s0woKnxuHrExLc5L2ArIH5BMkbonHPtt+5hSBM8oknp9M6QTuUmmAmJ2E0EdzCGONrO+8+ADPqvv6UX0nNcc7A==",
+			"version": "3.1095.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/token-providers/-/token-providers-3.1095.0.tgz",
+			"integrity": "sha512-65SudS6y4nzaYHybtqcpm3sHe5jLhdMn68HRKS1nUx690BtQeaAQOoujQ+dpOjBATIVGVgKKjEP8tR+U06QJQA==",
 			"license": "Apache-2.0",
 			"dependencies": {
-				"@aws-sdk/core": "^3.975.1",
-				"@aws-sdk/nested-clients": "^3.997.31",
-				"@aws-sdk/types": "^3.974.0",
-				"@smithy/core": "^3.29.2",
-				"@smithy/types": "^4.16.0",
+				"@aws-sdk/core": "^3.977.0",
+				"@aws-sdk/nested-clients": "^3.997.35",
+				"@aws-sdk/types": "^3.974.2",
+				"@smithy/core": "^3.29.8",
+				"@smithy/types": "^4.16.1",
 				"tslib": "^2.6.2"
 			},
 			"engines": {
@@ -320,12 +320,12 @@
 			}
 		},
 		"node_modules/@aws-sdk/types": {
-			"version": "3.974.0",
-			"resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.974.0.tgz",
-			"integrity": "sha512-QIBrw90CDm4O0UaIIzkU6DrFdeJzEb2Va5EPEVpyldj6sHJxB6cshhStJuhZxk3wR3PmjJlYsjPmY1kNb+KGBg==",
+			"version": "3.974.2",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.974.2.tgz",
+			"integrity": "sha512-3W6IUtSxFbH6X7Wb7DzGCV5QiFQsd0g8bOfntpmDxQlzBoKWUMBu/JPQR0DwkE+Hpnxd6db1tXbOwdeHddG6cA==",
 			"license": "Apache-2.0",
 			"dependencies": {
-				"@smithy/types": "^4.16.0",
+				"@smithy/types": "^4.16.1",
 				"tslib": "^2.6.2"
 			},
 			"engines": {
@@ -333,12 +333,12 @@
 			}
 		},
 		"node_modules/@aws-sdk/xml-builder": {
-			"version": "3.972.34",
-			"resolved": "https://registry.npmjs.org/@aws-sdk/xml-builder/-/xml-builder-3.972.34.tgz",
-			"integrity": "sha512-wHhWL1y7sN3enBA8POrPpQM5jCcmu2ozyhbRei4c8OjVcEaEs6yLucLa/pla457ggS/ysuy7bosagz3HaJkZXA==",
+			"version": "3.972.37",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/xml-builder/-/xml-builder-3.972.37.tgz",
+			"integrity": "sha512-zKq4HQum8JwDyEuyfuI4bbiAcU0KxP6qy+9PR/IsR92IyE/DaBAikzAS50tjxip4bqIIANpCcG+Yyj6CVhXupg==",
 			"license": "Apache-2.0",
 			"dependencies": {
-				"@smithy/types": "^4.16.0",
+				"@smithy/types": "^4.16.1",
 				"tslib": "^2.6.2"
 			},
 			"engines": {
@@ -557,9 +557,9 @@
 			}
 		},
 		"node_modules/@biomejs/biome": {
-			"version": "2.5.3",
-			"resolved": "https://registry.npmjs.org/@biomejs/biome/-/biome-2.5.3.tgz",
-			"integrity": "sha512-MrJswFdei9EfDwwUy2tQrPDpK0AO+RmMFvBoaaJ6ayBc3sUbHdCE+XG5N8vp+5So41ZupZJQm0roHFFhMGVD7A==",
+			"version": "2.5.5",
+			"resolved": "https://registry.npmjs.org/@biomejs/biome/-/biome-2.5.5.tgz",
+			"integrity": "sha512-r1S8nFsAG1MY+vJFZALzIvwXAJv6ejDQ0mxP21Tgr9YK3ZFtjrvbBwDdNhx1rUqvccEIeNg20cYCNzl6Cr69pQ==",
 			"dev": true,
 			"license": "MIT OR Apache-2.0",
 			"bin": {
@@ -573,20 +573,20 @@
 				"url": "https://opencollective.com/biome"
 			},
 			"optionalDependencies": {
-				"@biomejs/cli-darwin-arm64": "2.5.3",
-				"@biomejs/cli-darwin-x64": "2.5.3",
-				"@biomejs/cli-linux-arm64": "2.5.3",
-				"@biomejs/cli-linux-arm64-musl": "2.5.3",
-				"@biomejs/cli-linux-x64": "2.5.3",
-				"@biomejs/cli-linux-x64-musl": "2.5.3",
-				"@biomejs/cli-win32-arm64": "2.5.3",
-				"@biomejs/cli-win32-x64": "2.5.3"
+				"@biomejs/cli-darwin-arm64": "2.5.5",
+				"@biomejs/cli-darwin-x64": "2.5.5",
+				"@biomejs/cli-linux-arm64": "2.5.5",
+				"@biomejs/cli-linux-arm64-musl": "2.5.5",
+				"@biomejs/cli-linux-x64": "2.5.5",
+				"@biomejs/cli-linux-x64-musl": "2.5.5",
+				"@biomejs/cli-win32-arm64": "2.5.5",
+				"@biomejs/cli-win32-x64": "2.5.5"
 			}
 		},
 		"node_modules/@biomejs/cli-darwin-arm64": {
-			"version": "2.5.3",
-			"resolved": "https://registry.npmjs.org/@biomejs/cli-darwin-arm64/-/cli-darwin-arm64-2.5.3.tgz",
-			"integrity": "sha512-QhYP9muVQ0nUO5zztFuPbEwi4+94sJWVjaZds9aMi1l/KNZBiUjdiSUrGHsTaMGDXrYl+r4AS2sUKfgH3w+V3g==",
+			"version": "2.5.5",
+			"resolved": "https://registry.npmjs.org/@biomejs/cli-darwin-arm64/-/cli-darwin-arm64-2.5.5.tgz",
+			"integrity": "sha512-kUrAhXVWUrwmAUnV2iXSK7umxKFysTwvqK+Ty6ptUcLY/7T3SnCAjUowE4uvwaEej6nXZ7hu/dTtbokKdsPeag==",
 			"cpu": [
 				"arm64"
 			],
@@ -601,9 +601,9 @@
 			}
 		},
 		"node_modules/@biomejs/cli-darwin-x64": {
-			"version": "2.5.3",
-			"resolved": "https://registry.npmjs.org/@biomejs/cli-darwin-x64/-/cli-darwin-x64-2.5.3.tgz",
-			"integrity": "sha512-NC1Ss13UaW7QZX+y8j44bF7AP0jSJdBl6iRhe0MAkvaSqZy+mWg3GaXsrb+eSoHoGDBtaXWEbMVV0iVN2cZ7cQ==",
+			"version": "2.5.5",
+			"resolved": "https://registry.npmjs.org/@biomejs/cli-darwin-x64/-/cli-darwin-x64-2.5.5.tgz",
+			"integrity": "sha512-DamiYc5bUYZ2uxlfc+RLEPtz1Abb6PO5eTbOkufLpSGwd/7AMQAdxhFYiXmwwkJL8IsT8S7GvdgwDHqaMFAvKw==",
 			"cpu": [
 				"x64"
 			],
@@ -618,9 +618,9 @@
 			}
 		},
 		"node_modules/@biomejs/cli-linux-arm64": {
-			"version": "2.5.3",
-			"resolved": "https://registry.npmjs.org/@biomejs/cli-linux-arm64/-/cli-linux-arm64-2.5.3.tgz",
-			"integrity": "sha512-ksx1KWeyYW18ILL04msF/J4ZBtBDN33znYK8Z/aNv/vlBVxL9/g3mGP+omgHJKy4+KWbK87vcmmpmurfNjSgiA==",
+			"version": "2.5.5",
+			"resolved": "https://registry.npmjs.org/@biomejs/cli-linux-arm64/-/cli-linux-arm64-2.5.5.tgz",
+			"integrity": "sha512-lRKF/pH/1RiYiBKExi3TCZVAtvzEm77aifrvcNiDFrR9WxeAnDUjDnseb6y2XV85mjitLs6SILGm2XG77cHtSQ==",
 			"cpu": [
 				"arm64"
 			],
@@ -638,9 +638,9 @@
 			}
 		},
 		"node_modules/@biomejs/cli-linux-arm64-musl": {
-			"version": "2.5.3",
-			"resolved": "https://registry.npmjs.org/@biomejs/cli-linux-arm64-musl/-/cli-linux-arm64-musl-2.5.3.tgz",
-			"integrity": "sha512-fccix0w6xp6csCXgxeC0dU/3ecgRQal0y+cv2SP9ajNlhe7Yrk2Ug7UDe2j9AT9ZDYitkXpvUKgZjjuoYeP4Vg==",
+			"version": "2.5.5",
+			"resolved": "https://registry.npmjs.org/@biomejs/cli-linux-arm64-musl/-/cli-linux-arm64-musl-2.5.5.tgz",
+			"integrity": "sha512-U4WMl/sy/E/Q73vf15VspakLRRs2LDFcCeBxJnQfXzssb88zpV6PJPaQ3ezhQ7H6Ht2/8bvuZeHgJWzmoxllZg==",
 			"cpu": [
 				"arm64"
 			],
@@ -658,9 +658,9 @@
 			}
 		},
 		"node_modules/@biomejs/cli-linux-x64": {
-			"version": "2.5.3",
-			"resolved": "https://registry.npmjs.org/@biomejs/cli-linux-x64/-/cli-linux-x64-2.5.3.tgz",
-			"integrity": "sha512-yMkJtilsgvILDcVkh187aVLTb64xYsrxYajx5kym+r1ULkO5HUOfu9AYKLGQbOVLwJtT2utNw7hhFNg+17mUYA==",
+			"version": "2.5.5",
+			"resolved": "https://registry.npmjs.org/@biomejs/cli-linux-x64/-/cli-linux-x64-2.5.5.tgz",
+			"integrity": "sha512-H/O39nJEw/2Zm/fm7hrmxxoF8kK/aU1uCoPp70ruXVbomaAdLpJJnCmL11Q2JotT8QVHH06So04Oq53lCSwSwQ==",
 			"cpu": [
 				"x64"
 			],
@@ -678,9 +678,9 @@
 			}
 		},
 		"node_modules/@biomejs/cli-linux-x64-musl": {
-			"version": "2.5.3",
-			"resolved": "https://registry.npmjs.org/@biomejs/cli-linux-x64-musl/-/cli-linux-x64-musl-2.5.3.tgz",
-			"integrity": "sha512-O/yU9YKRUiHhmcjF2f38PSjseVk3G4VLWYc0G2HWpzdBVREV6G8IGWIVEFf7MFPfWIzNUIvPsEjeAZQIOgnLcQ==",
+			"version": "2.5.5",
+			"resolved": "https://registry.npmjs.org/@biomejs/cli-linux-x64-musl/-/cli-linux-x64-musl-2.5.5.tgz",
+			"integrity": "sha512-m7wC7tjX5Lrmo69dc4md8FeKpPU1NTCY1v7xUoQQ2vadWwNnBS0KZOG8471otFPHrTHihQJAjQPgMObpLvDe6A==",
 			"cpu": [
 				"x64"
 			],
@@ -698,9 +698,9 @@
 			}
 		},
 		"node_modules/@biomejs/cli-win32-arm64": {
-			"version": "2.5.3",
-			"resolved": "https://registry.npmjs.org/@biomejs/cli-win32-arm64/-/cli-win32-arm64-2.5.3.tgz",
-			"integrity": "sha512-cX5z+GYwRcqEok0AH3KSfQGgqYd0Nomfp6Fbe1uiTtELE38hdH2k842wQ9wLNaF/JJ7r4rjJQ4VR+ce+fRmQbw==",
+			"version": "2.5.5",
+			"resolved": "https://registry.npmjs.org/@biomejs/cli-win32-arm64/-/cli-win32-arm64-2.5.5.tgz",
+			"integrity": "sha512-7BryINPuYypLUAH3o/o5ZdgomJ4zn3EDR0ChZJst7n32S6ZhKbgHXuYydLu+YAnx59ehGFR0z/MG6qnzQi3Yyw==",
 			"cpu": [
 				"arm64"
 			],
@@ -715,9 +715,9 @@
 			}
 		},
 		"node_modules/@biomejs/cli-win32-x64": {
-			"version": "2.5.3",
-			"resolved": "https://registry.npmjs.org/@biomejs/cli-win32-x64/-/cli-win32-x64-2.5.3.tgz",
-			"integrity": "sha512-ExSaJWi4/u6+GXCszlSKpWSjKNbDseAYqqkCznsCsZ/4uidZ/BEqsCc5/3ctlq6dfIubdIIRSVLC/PG9xPl70Q==",
+			"version": "2.5.5",
+			"resolved": "https://registry.npmjs.org/@biomejs/cli-win32-x64/-/cli-win32-x64-2.5.5.tgz",
+			"integrity": "sha512-bIBFo+n6MIxdNcVFy5CrurbKiZQiUciK3bt8+O9I4wjFZNTfXLpi+giq47522eXqW5NBc9ulx7dR1SlZKi2J5g==",
 			"cpu": [
 				"x64"
 			],
@@ -1276,9 +1276,9 @@
 			}
 		},
 		"node_modules/@smithy/core": {
-			"version": "3.29.3",
-			"resolved": "https://registry.npmjs.org/@smithy/core/-/core-3.29.3.tgz",
-			"integrity": "sha512-L+Ys6ecjk5vwPMAKHBpPKlJ3DkqwNcnfEISXBZIsVvWG/XKXfsAP8mwIYlTeLcd2ElHdesPI8OuOmJSFAPhm6A==",
+			"version": "3.30.0",
+			"resolved": "https://registry.npmjs.org/@smithy/core/-/core-3.30.0.tgz",
+			"integrity": "sha512-dl2yRglDxfzH9uJ4fSo4zTaAHa0zH7+V7BZMRWy8hEYIKT1BiqMUK/CN6T3ADQ3kbA5N1tmUulroJ2UtONS7Kw==",
 			"license": "Apache-2.0",
 			"dependencies": {
 				"@smithy/types": "^4.16.1",
@@ -1289,12 +1289,12 @@
 			}
 		},
 		"node_modules/@smithy/credential-provider-imds": {
-			"version": "4.4.8",
-			"resolved": "https://registry.npmjs.org/@smithy/credential-provider-imds/-/credential-provider-imds-4.4.8.tgz",
-			"integrity": "sha512-q9J7JTiXrAhB8sDp4px97uEPT7CwKH61Co78grdNQvU8QZAdiuaSRhP0tUVf2ogy36RZTrlMU1rBmDEH+cnkiA==",
+			"version": "4.4.14",
+			"resolved": "https://registry.npmjs.org/@smithy/credential-provider-imds/-/credential-provider-imds-4.4.14.tgz",
+			"integrity": "sha512-QgbuahIb2qxQeZQvNK0sw3aF3JH5zwH8j2lLp5DUasVXexGGMWULAR+7z0omPXFolCP/m5wN9M5lm9EGdSviTQ==",
 			"license": "Apache-2.0",
 			"dependencies": {
-				"@smithy/core": "^3.29.3",
+				"@smithy/core": "^3.30.0",
 				"@smithy/types": "^4.16.1",
 				"tslib": "^2.6.2"
 			},
@@ -1303,12 +1303,12 @@
 			}
 		},
 		"node_modules/@smithy/fetch-http-handler": {
-			"version": "5.6.5",
-			"resolved": "https://registry.npmjs.org/@smithy/fetch-http-handler/-/fetch-http-handler-5.6.5.tgz",
-			"integrity": "sha512-SuqeisTyPoiIPtIYru/sGxGyXzmZ+8nnFOhC+qRPglt06Ebd1yH//CDltZB2J/3WBNVhwfUaZ0EtHB3cm2X32g==",
+			"version": "5.6.11",
+			"resolved": "https://registry.npmjs.org/@smithy/fetch-http-handler/-/fetch-http-handler-5.6.11.tgz",
+			"integrity": "sha512-o0Zkj1nKqJAoq+a+BrkhU39tRftMNjLwpc/z06Frfl43wpbHrJMaSAVZE4vTqlxtVkNaGaT0bIDxOp7tkFTuQQ==",
 			"license": "Apache-2.0",
 			"dependencies": {
-				"@smithy/core": "^3.29.3",
+				"@smithy/core": "^3.30.0",
 				"@smithy/types": "^4.16.1",
 				"tslib": "^2.6.2"
 			},
@@ -1317,12 +1317,12 @@
 			}
 		},
 		"node_modules/@smithy/node-http-handler": {
-			"version": "4.9.5",
-			"resolved": "https://registry.npmjs.org/@smithy/node-http-handler/-/node-http-handler-4.9.5.tgz",
-			"integrity": "sha512-bNqdxTQTxmLbomSmlkZFz8L6B/feQ2HHzw4L2zY7Ecp2XffYAZq2uzdWDdxJHJFbEvqd+SRuluJso0P8+xPdbw==",
+			"version": "4.9.11",
+			"resolved": "https://registry.npmjs.org/@smithy/node-http-handler/-/node-http-handler-4.9.11.tgz",
+			"integrity": "sha512-slbzbz8taEOzoXv/9y34YNBoE+ZHmddLykCgjDAjvMAsu2nM5s2Gzwa5OGF721tD8s+CKeFUBds5lSj9lcbuDg==",
 			"license": "Apache-2.0",
 			"dependencies": {
-				"@smithy/core": "^3.29.3",
+				"@smithy/core": "^3.30.0",
 				"@smithy/types": "^4.16.1",
 				"tslib": "^2.6.2"
 			},
@@ -1331,12 +1331,12 @@
 			}
 		},
 		"node_modules/@smithy/signature-v4": {
-			"version": "5.6.4",
-			"resolved": "https://registry.npmjs.org/@smithy/signature-v4/-/signature-v4-5.6.4.tgz",
-			"integrity": "sha512-B89bpf2t/y/wia6LZ+4JfHXYQT9PnVftsH05rgJKKIStS7r/4XSs9HOjtPoLtgcA6HCW9jVqX5DBbq7E0PAkiQ==",
+			"version": "5.6.10",
+			"resolved": "https://registry.npmjs.org/@smithy/signature-v4/-/signature-v4-5.6.10.tgz",
+			"integrity": "sha512-EXhWePm3SXJAX38npIy4TXL2Aex/OVgCClTjelN2QHw/U+8CQUH8C7AaxsVzQcYieYPseywn48s89DmvuGjiAg==",
 			"license": "Apache-2.0",
 			"dependencies": {
-				"@smithy/core": "^3.29.3",
+				"@smithy/core": "^3.30.0",
 				"@smithy/types": "^4.16.1",
 				"tslib": "^2.6.2"
 			},
@@ -3062,9 +3062,9 @@
 			"license": "0BSD"
 		},
 		"node_modules/tsx": {
-			"version": "4.23.0",
-			"resolved": "https://registry.npmjs.org/tsx/-/tsx-4.23.0.tgz",
-			"integrity": "sha512-eUdUIaCr963q2h5u3+QwvYp0+eqPvn+egeqZUm0hwERCqqx1E3kK5ehbGCvqSE5MQAULr67ww0cA3jKc3YkM1w==",
+			"version": "4.23.1",
+			"resolved": "https://registry.npmjs.org/tsx/-/tsx-4.23.1.tgz",
+			"integrity": "sha512-GQHnkIfxyx1wYCOS/wonik5MVRZU9hi1TEZmzGZSCJB1y9YgoZ8H6itNE/u4suE+yLmOzuE4E5S4TZ/ZX2wcWQ==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
@@ -3122,9 +3122,9 @@
 			}
 		},
 		"node_modules/undici": {
-			"version": "8.7.0",
-			"resolved": "https://registry.npmjs.org/undici/-/undici-8.7.0.tgz",
-			"integrity": "sha512-N7iQtfyLhIMOFgQubvmLV26svHpO0bqKnAiWotTQCVKCmWrcGbBotPuW1x+xwYZ2VHdSTVUfPQQnlEt1/LouTQ==",
+			"version": "8.8.0",
+			"resolved": "https://registry.npmjs.org/undici/-/undici-8.8.0.tgz",
+			"integrity": "sha512-ubshXMXwF3MQIMF1y/WxZdNBnjEKeSg2wF5mcGUtU55YTw34tnVVpKRlLf7ruDXZ5344KokPVX4RBx1wJm64Bw==",
 			"license": "MIT",
 			"engines": {
 				"node": ">=22.19.0"

--- a/services/puppeteer-worker/package.json
+++ b/services/puppeteer-worker/package.json
@@ -29,23 +29,23 @@
 		"node": ">=24.0.0"
 	},
 	"devDependencies": {
-		"@biomejs/biome": "2.5.3",
+		"@biomejs/biome": "2.5.5",
 		"esbuild": "^0.28.1",
-		"tsx": "^4.23.0",
+		"tsx": "^4.23.1",
 		"typescript": "^7.0.2"
 	},
 	"overrides": {
 		"uuid": "^11.1.1"
 	},
 	"dependencies": {
-		"@aws-sdk/client-s3": "^3.1084.0",
-		"@aws-sdk/s3-request-presigner": "^3.1084.0",
+		"@aws-sdk/client-s3": "^3.1094.0",
+		"@aws-sdk/s3-request-presigner": "^3.1094.0",
 		"@azure/storage-blob": "^12.33.0",
 		"@google-cloud/storage": "^7.21.0",
 		"ioredis": "^5.11.1",
 		"minio": "^8.0.7",
 		"puppeteer": "^25.3.0",
-		"undici": "^8.7.0",
+		"undici": "^8.8.0",
 		"yaml": "^2.9.0"
 	}
 }

--- a/services/puppeteer-worker/src/helpers.ts
+++ b/services/puppeteer-worker/src/helpers.ts
@@ -1,0 +1,101 @@
+/**
+ * Shared helpers for puppeteer-worker
+ * Centralizes common patterns: page event wrapping, safe async ops, error logging
+ */
+
+import type { Page } from "puppeteer";
+import { logger, pageLogger } from "./logger.js";
+
+/**
+ * Attach a page event handler wrapped in standardized error logging.
+ * Prevents unhandled errors from crashing the process when a page event handler throws.
+ */
+export function onPageEvent<K extends keyof import("puppeteer").PageEvents>(
+	page: Page,
+	event: K,
+	handler: (arg: import("puppeteer").PageEvents[K]) => void,
+): void {
+	page.on(event, (arg: import("puppeteer").PageEvents[K]) => {
+		try {
+			handler(arg);
+		} catch (err) {
+			pageLogger.error(
+				err instanceof Error ? err : new Error(String(err)),
+				`Error in "${String(event)}" handler`,
+				{ event: String(event) },
+			);
+		}
+	});
+}
+
+/**
+ * Attach browser console logging to a page using standardized log levels.
+ * Extracts console type, text, and location for structured logging.
+ */
+export function attachConsoleLogger(
+	page: Page,
+	getPageUrl: () => string | undefined,
+): void {
+	onPageEvent(page, "console", (msg) => {
+		const t = msg.type() as string;
+		const text = msg.text();
+		const loc = msg.location();
+		const ctx = {
+			source: "browser_console",
+			consoleType: t,
+			pageUrl: getPageUrl(),
+			...(loc && { location: loc }),
+			consoleText: text,
+		};
+		switch (t) {
+			case "error":
+			case "assert":
+				pageLogger.error(
+					{ name: "BrowserConsoleError", message: text },
+					"[Page] console error",
+					ctx,
+				);
+				break;
+			case "warning":
+				pageLogger.warn("[Page] console warn", ctx);
+				break;
+			case "debug":
+			case "trace":
+			case "timeEnd":
+				pageLogger.debug("[Page] console debug", ctx);
+				break;
+			default:
+				pageLogger.info("[Page] console", ctx);
+		}
+	});
+}
+
+/**
+ * Attach pageerror logging to a page.
+ */
+export function attachPageErrorLogger(
+	page: Page,
+	getPageUrl: () => string | undefined,
+): void {
+	onPageEvent(page, "pageerror", (error) => {
+		pageLogger.error(error, "[Page] runtime error", {
+			source: "browser_pageerror",
+			pageUrl: getPageUrl(),
+		});
+	});
+}
+
+/**
+ * Run an async operation and swallow errors during shutdown,
+ * logging them at warn level instead of letting them propagate.
+ */
+export async function safeAsync(
+	label: string,
+	fn: () => Promise<void>,
+): Promise<void> {
+	try {
+		await fn();
+	} catch (error) {
+		logger.warn(`${label} error (swallowed)`, { err: error });
+	}
+}

--- a/services/puppeteer-worker/src/puppeteer-runner.ts
+++ b/services/puppeteer-worker/src/puppeteer-runner.ts
@@ -23,24 +23,28 @@ async function loadClientMonitoringSource(): Promise<string> {
 	return __clientMonitoringCache;
 }
 
+import {
+	type ClientEvent,
+	getClientEventCategory,
+	mapClientEventPayload,
+	mapClientEventToMethod,
+} from "./client-event-map.js";
 import { EventMonitor } from "./event-monitor.js";
 import { EventShipper } from "./event-shipper.js";
 import { type CapturedFile, FileCapture } from "./file-capture.js";
-import { logger, pageLogger } from "./logger.js";
+import {
+	attachConsoleLogger,
+	attachPageErrorLogger,
+	safeAsync,
+} from "./helpers.js";
+import { logger } from "./logger.js";
 import type {
 	Config,
-	ExecutionResult,
 	EventPayload,
+	ExecutionResult,
 	NetworkEventPayload,
 	SelfContainedEvent,
 } from "./types.js";
-
-import {
-	type ClientEvent,
-	mapClientEventToMethod,
-	mapClientEventPayload,
-	getClientEventCategory,
-} from "./client-event-map.js";
 
 type MonitoringGlobal = {
 	__puppeteerMonitoringActive?: boolean;
@@ -137,7 +141,10 @@ export class PuppeteerRunner {
 		};
 	}
 
-	private buildFailureResult(error: unknown, startTime: number): ExecutionResult {
+	private buildFailureResult(
+		error: unknown,
+		startTime: number,
+	): ExecutionResult {
 		return {
 			sessionId: this.sessionId,
 			success: false,
@@ -207,46 +214,9 @@ export class PuppeteerRunner {
 
 		this.cdpSession = await this.page.createCDPSession();
 
-		// Log browser console consistently at info; include original type for context
-		this.page.on("console", (msg) => {
-			const t = msg.type() as string;
-			const text = msg.text();
-			const loc = msg.location();
-			const ctx = {
-				source: "browser_console",
-				consoleType: t,
-				pageUrl: this.page?.url(),
-				...(loc && { location: loc }),
-				consoleText: text,
-			};
-			switch (t) {
-				case "error":
-				case "assert":
-					pageLogger.error(
-						{ name: "BrowserConsoleError", message: text },
-						"[Page] console error",
-						ctx,
-					);
-					break;
-				case "warning":
-					pageLogger.warn("[Page] console warn", ctx);
-					break;
-				case "debug":
-				case "trace":
-				case "timeEnd":
-					pageLogger.debug("[Page] console debug", ctx);
-					break;
-				default:
-					pageLogger.info("[Page] console", ctx);
-			}
-		});
-
-		this.page.on("pageerror", (error) => {
-			pageLogger.error(error, "[Page] runtime error", {
-				source: "browser_pageerror",
-				pageUrl: this.page?.url(),
-			});
-		});
+		// Log browser console and page errors via shared helpers
+		attachConsoleLogger(this.page, () => this.page?.url());
+		attachPageErrorLogger(this.page, () => this.page?.url());
 
 		// Initialize file capture
 		if (config.fileCapture?.enabled) {
@@ -1070,16 +1040,24 @@ export class PuppeteerRunner {
 	}
 
 	private async cleanup(): Promise<void> {
-		try {
-			this.stopEventStreaming();
-			this.responseEventIndexByRequestId.clear();
-			await this.eventMonitor?.cleanup();
-			await this.fileCapture?.cleanup();
-			await this.page?.close();
-			await this.browser?.close();
-		} catch (error) {
-			logger.warn("Cleanup error", { err: error });
-		}
+		this.stopEventStreaming();
+		this.responseEventIndexByRequestId.clear();
+		await safeAsync(
+			"EventMonitor cleanup",
+			() => this.eventMonitor?.cleanup() ?? Promise.resolve(),
+		);
+		await safeAsync(
+			"FileCapture cleanup",
+			() => this.fileCapture?.cleanup() ?? Promise.resolve(),
+		);
+		await safeAsync(
+			"Page close",
+			() => this.page?.close() ?? Promise.resolve(),
+		);
+		await safeAsync(
+			"Browser close",
+			() => this.browser?.close() ?? Promise.resolve(),
+		);
 	}
 
 	// Getter for events (useful for testing)

--- a/services/puppeteer-worker/src/puppeteer-runner.ts
+++ b/services/puppeteer-worker/src/puppeteer-runner.ts
@@ -1042,22 +1042,18 @@ export class PuppeteerRunner {
 	private async cleanup(): Promise<void> {
 		this.stopEventStreaming();
 		this.responseEventIndexByRequestId.clear();
-		await safeAsync(
-			"EventMonitor cleanup",
-			() => this.eventMonitor?.cleanup() ?? Promise.resolve(),
-		);
-		await safeAsync(
-			"FileCapture cleanup",
-			() => this.fileCapture?.cleanup() ?? Promise.resolve(),
-		);
-		await safeAsync(
-			"Page close",
-			() => this.page?.close() ?? Promise.resolve(),
-		);
-		await safeAsync(
-			"Browser close",
-			() => this.browser?.close() ?? Promise.resolve(),
-		);
+		await safeAsync("EventMonitor cleanup", async () => {
+			await this.eventMonitor?.cleanup();
+		});
+		await safeAsync("FileCapture cleanup", async () => {
+			await this.fileCapture?.cleanup();
+		});
+		await safeAsync("Page close", async () => {
+			await this.page?.close();
+		});
+		await safeAsync("Browser close", async () => {
+			await this.browser?.close();
+		});
 	}
 
 	// Getter for events (useful for testing)


### PR DESCRIPTION
## Summary

Single chore PR combining dependency bumps and code cleanup to reduce CI/CD time.

### Dependency Bumps (PRs #196, #200, #201)
- **Actions**: `actions/checkout` v7.0.0 → v7.0.1, `docker/login-action` v4.4.0 → v4.5.1
- **Frontend**: `@biomejs/biome` 2.5.0 → 2.5.5, `lucide` 1.21.0 → 1.25.0
- **Puppeteer-worker**: `@aws-sdk/client-s3` ^3.1084.0 → ^3.1094.0, `undici` ^8.7.0 → ^8.8.0, `@biomejs/biome` 2.5.3 → 2.5.5

### Issue #176 — Centralize delete-error OnError callbacks
- Added `DefaultDeleteOnError()` and `DefaultDeleteOnSuccess()` helpers to `ui_base.go`
- Refactored all 4 delete handlers (AlertSink, Site, Job, Secret) to use shared helpers
- Removed ~50 lines of duplicated HTMX toast + list re-render boilerplate
- Deleted `handleAlertSinkDeleteError`, `fetchAlertSinksForError`, `handleSecretDeleteError`

### Issue #177 — DRY puppeteer-worker helpers
- Extracted `onPageEvent()`, `attachConsoleLogger()`, `attachPageErrorLogger()`, `safeAsync()` into new `helpers.ts`
- Refactored `PuppeteerRunner` to use shared helpers for page event handling and cleanup
- Each cleanup step now individually error-handled via `safeAsync()`

### Issue #178 — Test assertion helpers
- Added `AssertBodyContains`, `AssertHTMXResponse`, `AssertHTMXToast`, `AssertStatus`, `AssertStatusAndBody` to `testhelpers.go`
- Converted assertions in `ui_alerts_test.go`, `ui_jobs_test.go`, `ui_sites_list_test.go`

## Testing
- ✅ `go build ./...` — clean
- ✅ `go vet ./internal/http/...` — clean
- ✅ `go test ./internal/http/...` — all pass
- ✅ `npx tsc --noEmit` — clean
- ✅ `npm test` — 21/22 pass (1 skipped)
- ✅ `npx biome check` — clean

Closes #176, closes #177, closes #178
Supersedes #196, #200, #201